### PR TITLE
Fix doxygen build due to renamed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,5 @@ jobs:
           sudo apt-get install -y libclang-9-dev
       - name: Run Doxygen And Verify Stdout Is Empty
         run: |
-          doxygen docs/doxygen/config.doxyfile | tee doxyoutput.txt
+          doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
           if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -27,17 +27,17 @@ The configurations for memory estimation are defined <a href="https://github.com
         <td><b>With -Os Optimization</b></td>
     </tr>
     <tr>
-        <td>mqtt.c</td>
+        <td>core_mqtt.c</td>
         <td>3.3K</td>
         <td>2.9K</td>
     </tr>
     <tr>
-        <td>mqtt_state.c</td>
+        <td>core_mqtt_state.c</td>
         <td>2.1K</td>
         <td>1.6K</td>
     </tr>
     <tr>
-        <td>mqtt_lightweight.c</td>
+        <td>core_mqtt_lightweight.c</td>
         <td>3.5K</td>
         <td>2.9K</td>
     </tr>
@@ -124,123 +124,123 @@ Lightweight functions of the MQTT library:<br><br>
 @subpage mqtt_getincomingpackettypeandlength_function <br>
 
 @page mqtt_init_function MQTT_Init
-@snippet mqtt.h declare_mqtt_init
+@snippet core_mqtt.h declare_mqtt_init
 @copydoc MQTT_Init
 
 @page mqtt_connect_function MQTT_Connect
-@snippet mqtt.h declare_mqtt_connect
+@snippet core_mqtt.h declare_mqtt_connect
 @copydoc MQTT_Connect
 
 @page mqtt_subscribe_function MQTT_Subscribe
-@snippet mqtt.h declare_mqtt_subscribe
+@snippet core_mqtt.h declare_mqtt_subscribe
 @copydoc MQTT_Subscribe
 
 @page mqtt_publish_function MQTT_Publish
-@snippet mqtt.h declare_mqtt_publish
+@snippet core_mqtt.h declare_mqtt_publish
 @copydoc MQTT_Publish
 
 @page mqtt_ping_function MQTT_Ping
-@snippet mqtt.h declare_mqtt_ping
+@snippet core_mqtt.h declare_mqtt_ping
 @copydoc MQTT_Ping
 
 @page mqtt_unsubscribe_function MQTT_Unsubscribe
-@snippet mqtt.h declare_mqtt_unsubscribe
+@snippet core_mqtt.h declare_mqtt_unsubscribe
 @copydoc MQTT_Unsubscribe
 
 @page mqtt_disconnect_function MQTT_Disconnect
-@snippet mqtt.h declare_mqtt_disconnect
+@snippet core_mqtt.h declare_mqtt_disconnect
 @copydoc MQTT_Disconnect
 
 @page mqtt_processloop_function MQTT_ProcessLoop
-@snippet mqtt.h declare_mqtt_processloop
+@snippet core_mqtt.h declare_mqtt_processloop
 @copydoc MQTT_ProcessLoop
 
 @page mqtt_receiveloop_function MQTT_ReceiveLoop
-@snippet mqtt.h declare_mqtt_receiveloop
+@snippet core_mqtt.h declare_mqtt_receiveloop
 @copydoc MQTT_ReceiveLoop
 
 @page mqtt_getpacketid_function MQTT_GetPacketId
-@snippet mqtt.h declare_mqtt_getpacketid
+@snippet core_mqtt.h declare_mqtt_getpacketid
 @copydoc MQTT_GetPacketId
 
 @page mqtt_getsubackstatuscodes_function MQTT_GetSubAckStatusCodes
-@snippet mqtt.h declare_mqtt_getsubackstatuscodes
+@snippet core_mqtt.h declare_mqtt_getsubackstatuscodes
 @copydoc MQTT_GetSubAckStatusCodes
 
 @page mqtt_status_strerror_function MQTT_Status_strerror
-@snippet mqtt.h declare_mqtt_status_strerror
+@snippet core_mqtt.h declare_mqtt_status_strerror
 @copydoc MQTT_Status_strerror
 
 @page mqtt_publishtoresend_function MQTT_PublishToResend
-@snippet mqtt_state.h declare_mqtt_publishtoresend
+@snippet core_mqtt_state.h declare_mqtt_publishtoresend
 @copydoc MQTT_PublishToResend
 
 @page mqtt_getconnectpacketsize_function MQTT_GetConnectPacketSize
-@snippet mqtt_lightweight.h declare_mqtt_getconnectpacketsize
+@snippet core_mqtt_lightweight.h declare_mqtt_getconnectpacketsize
 @copydoc MQTT_GetConnectPacketSize
 
 @page mqtt_serializeconnect_function MQTT_SerializeConnect
-@snippet mqtt_lightweight.h declare_mqtt_serializeconnect
+@snippet core_mqtt_lightweight.h declare_mqtt_serializeconnect
 @copydoc MQTT_SerializeConnect
 
 @page mqtt_getsubscribepacketsize_function MQTT_GetSubscribePacketSize
-@snippet mqtt_lightweight.h declare_mqtt_getsubscribepacketsize
+@snippet core_mqtt_lightweight.h declare_mqtt_getsubscribepacketsize
 @copydoc MQTT_GetSubscribePacketSize
 
 @page mqtt_serializesubscribe_function MQTT_SerializeSubscribe
-@snippet mqtt_lightweight.h declare_mqtt_serializesubscribe
+@snippet core_mqtt_lightweight.h declare_mqtt_serializesubscribe
 @copydoc MQTT_SerializeSubscribe
 
 @page mqtt_getunsubscribepacketsize_function MQTT_GetUnsubscribePacketSize
-@snippet mqtt_lightweight.h declare_mqtt_getunsubscribepacketsize
+@snippet core_mqtt_lightweight.h declare_mqtt_getunsubscribepacketsize
 @copydoc MQTT_GetUnsubscribePacketSize
 
 @page mqtt_serializeunsubscribe_function MQTT_SerializeUnsubscribe
-@snippet mqtt_lightweight.h declare_mqtt_serializeunsubscribe
+@snippet core_mqtt_lightweight.h declare_mqtt_serializeunsubscribe
 @copydoc MQTT_SerializeUnsubscribe
 
 @page mqtt_getpublishpacketsize_function MQTT_GetPublishPacketSize
-@snippet mqtt_lightweight.h declare_mqtt_getpublishpacketsize
+@snippet core_mqtt_lightweight.h declare_mqtt_getpublishpacketsize
 @copydoc MQTT_GetPublishPacketSize
 
 @page mqtt_serializepublish_function MQTT_SerializePublish
-@snippet mqtt_lightweight.h declare_mqtt_serializepublish
+@snippet core_mqtt_lightweight.h declare_mqtt_serializepublish
 @copydoc MQTT_SerializePublish
 
 @page mqtt_serializepublishheader_function MQTT_SerializePublishHeader
-@snippet mqtt_lightweight.h declare_mqtt_serializepublishheader
+@snippet core_mqtt_lightweight.h declare_mqtt_serializepublishheader
 @copydoc MQTT_SerializePublishHeader
 
 @page mqtt_serializeack_function MQTT_SerializeAck
-@snippet mqtt_lightweight.h declare_mqtt_serializeack
+@snippet core_mqtt_lightweight.h declare_mqtt_serializeack
 @copydoc MQTT_SerializeAck
 
 @page mqtt_getdisconnectpacketsize_function MQTT_GetDisconnectPacketSize
-@snippet mqtt_lightweight.h declare_mqtt_getdisconnectpacketsize
+@snippet core_mqtt_lightweight.h declare_mqtt_getdisconnectpacketsize
 @copydoc MQTT_GetDisconnectPacketSize
 
 @page mqtt_serializedisconnect_function MQTT_SerializeDisconnect
-@snippet mqtt_lightweight.h declare_mqtt_serializedisconnect
+@snippet core_mqtt_lightweight.h declare_mqtt_serializedisconnect
 @copydoc MQTT_SerializeDisconnect
 
 @page mqtt_getpingreqpacketsize_function MQTT_GetPingreqPacketSize
-@snippet mqtt_lightweight.h declare_mqtt_getpingreqpacketsize
+@snippet core_mqtt_lightweight.h declare_mqtt_getpingreqpacketsize
 @copydoc MQTT_GetPingreqPacketSize
 
 @page mqtt_serializepingreq_function MQTT_SerializePingreq
-@snippet mqtt_lightweight.h declare_mqtt_serializepingreq
+@snippet core_mqtt_lightweight.h declare_mqtt_serializepingreq
 @copydoc MQTT_SerializePingreq
 
 @page mqtt_deserializepublish_function MQTT_DeserializePublish
-@snippet mqtt_lightweight.h declare_mqtt_deserializepublish
+@snippet core_mqtt_lightweight.h declare_mqtt_deserializepublish
 @copydoc MQTT_DeserializePublish
 
 @page mqtt_deserializeack_function MQTT_DeserializeAck
-@snippet mqtt_lightweight.h declare_mqtt_deserializeack
+@snippet core_mqtt_lightweight.h declare_mqtt_deserializeack
 @copydoc MQTT_DeserializeAck
 
 @page mqtt_getincomingpackettypeandlength_function MQTT_GetIncomingPacketTypeAndLength
-@snippet mqtt_lightweight.h declare_mqtt_getincomingpackettypeandlength
+@snippet core_mqtt_lightweight.h declare_mqtt_getincomingpackettypeandlength
 @copydoc MQTT_GetIncomingPacketTypeAndLength
 */
 

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file mqtt.c
+ * @file core_mqtt.c
  * @brief Implements the user-facing functions in mqtt.h.
  */
 #include <string.h>

--- a/source/core_mqtt_lightweight.c
+++ b/source/core_mqtt_lightweight.c
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file mqtt_lightweight.c
+ * @file core_mqtt_lightweight.c
  * @brief Implements the user-facing functions in mqtt_lightweight.h.
  */
 #include <string.h>

--- a/source/core_mqtt_state.c
+++ b/source/core_mqtt_state.c
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file mqtt_state.c
+ * @file core_mqtt_state.c
  * @brief Implements the functions in mqtt_state.h.
  */
 #include <assert.h>

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file mqtt.h
+ * @file core_mqtt.h
  * @brief User-facing functions of the MQTT 3.1.1 library.
  */
 #ifndef CORE_MQTT_H

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file mqtt_config_defaults.h
+ * @file core_mqtt_config_defaults.h
  * @brief This represents the default values for the configuration macros
  * for the MQTT library.
  *

--- a/source/include/core_mqtt_lightweight.h
+++ b/source/include/core_mqtt_lightweight.h
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file mqtt_lightweight.h
+ * @file core_mqtt_lightweight.h
  * @brief User-facing functions for serializing and deserializing MQTT 3.1.1
  * packets. This header should be included for building a lightweight MQTT
  * client bypassing the managed CSDK MQTT library API in mqtt.h.

--- a/source/include/core_mqtt_state.h
+++ b/source/include/core_mqtt_state.h
@@ -20,7 +20,7 @@
  */
 
 /**
- * @file mqtt_state.h
+ * @file core_mqtt_state.h
  * @brief Function to keep state of MQTT PUBLISH packet deliveries.
  */
 #ifndef CORE_MQTT_STATE_H


### PR DESCRIPTION
*Description*:
Renaming files with the `core_` prefix broke doxygen builds as doxygen `@file` targets were not updated. This fixes the errors in the doxygen build
