### PR TITLE
Address MISRA 2.3 Rule violation

### DIFF
--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -819,8 +819,8 @@ MQTTStatus_t MQTT_MatchTopic( const char * pTopicName,
  *
  *          for( int i = 0; i < numCodes; i++ )
  *          {
- *              // The only failure code is 0x80 = MQTTSubAckFailure.
- *              if( pCodes[ i ] == MQTTSubAckFailure )
+ *              // The only failure code is 0x80 = MQTT_SUBACK_STATUS_FAILURE.
+ *              if( pCodes[ i ] == MQTT_SUBACK_STATUS_FAILURE )
  *              {
  *                  // The subscription failed, we may want to retry the
  *                  // subscription in pSubscribes[ i ] outside of this callback.

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -51,25 +51,25 @@
  * @ingroup mqtt_constants
  * @brief The success status code for QoS 0 in the SUBACK response to a subscription request.
  */
-#define MQTT_SUBACK_STATUS_SUCCESS_QOS_0    0x00
+#define MQTT_SUBACK_STATUS_SUCCESS_QOS_0    ( ( uint8_t ) 0x00U )
 
 /**
  * @ingroup mqtt_constants
  * @brief The success status code for QoS 1 in the SUBACK response to a subscription request.
  */
-#define MQTT_SUBACK_STATUS_SUCCESS_QOS_1    0x01
+#define MQTT_SUBACK_STATUS_SUCCESS_QOS_1    ( ( uint8_t ) 0x01U )
 
 /**
  * @ingroup mqtt_constants
  * @brief The success status code for QoS 2 in the SUBACK response to a subscription request.
  */
-#define MQTT_SUBACK_STATUS_SUCCESS_QOS_2    0x02
+#define MQTT_SUBACK_STATUS_SUCCESS_QOS_2    ( ( uint8_t ) 0x02U )
 
 /**
  * @ingroup mqtt_constants
  * @brief The failure status code in the SUBACK response to a subscription request.
  */
-#define MQTT_SUBACK_STATUS_FAILURE          0x80
+#define MQTT_SUBACK_STATUS_FAILURE          ( ( uint8_t ) 0x80U )
 
 
 /* Structures defined in this file. */

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -45,7 +45,32 @@
  *
  * Zero is an invalid packet identifier as per MQTT v3.1.1 spec.
  */
-#define MQTT_PACKET_ID_INVALID    ( ( uint16_t ) 0U )
+#define MQTT_PACKET_ID_INVALID              ( ( uint16_t ) 0U )
+
+/**
+ * @ingroup mqtt_constants
+ * @brief The success status code for QoS 0 in the SUBACK response to a subscription request.
+ */
+#define MQTT_SUBACK_STATUS_SUCCESS_QOS_0    0x00
+
+/**
+ * @ingroup mqtt_constants
+ * @brief The success status code for QoS 1 in the SUBACK response to a subscription request.
+ */
+#define MQTT_SUBACK_STATUS_SUCCESS_QOS_1    0x01
+
+/**
+ * @ingroup mqtt_constants
+ * @brief The success status code for QoS 2 in the SUBACK response to a subscription request.
+ */
+#define MQTT_SUBACK_STATUS_SUCCESS_QOS_2    0x02
+
+/**
+ * @ingroup mqtt_constants
+ * @brief The failure status code in the SUBACK response to a subscription request.
+ */
+#define MQTT_SUBACK_STATUS_FAILURE          0x80
+
 
 /* Structures defined in this file. */
 struct MQTTPubAckInfo;
@@ -118,18 +143,6 @@ typedef enum MQTTPubAckType
     MQTTPubrel, /**< @brief PUBRELs are sent in response to a PUBREC. */
     MQTTPubcomp /**< @brief PUBCOMPs are sent in response to a PUBREL. */
 } MQTTPubAckType_t;
-
-/**
- * @ingroup mqtt_enum_types
- * @brief The status codes in the SUBACK response to a subscription request.
- */
-typedef enum MQTTSubAckStatus
-{
-    MQTTSubAckSuccessQos0 = 0x00, /**< @brief Success with a maximum delivery at QoS 0 . */
-    MQTTSubAckSuccessQos1 = 0x01, /**< @brief Success with a maximum delivery at QoS 1. */
-    MQTTSubAckSuccessQos2 = 0x02, /**< @brief Success with a maximum delivery at QoS 2. */
-    MQTTSubAckFailure = 0x80      /**< @brief Failure. */
-} MQTTSubAckStatus_t;
 
 /**
  * @ingroup mqtt_struct_types

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -769,7 +769,11 @@ MQTTStatus_t MQTT_MatchTopic( const char * pTopicName,
  *  - 0x01 - Success - Maximum QoS 1
  *  - 0x02 - Success - Maximum QoS 2
  *  - 0x80 - Failure
- * Refer to #MQTTSubAckStatus_t for the status codes.
+ * The above status can be used through the following macro constants:
+ * #MQTT_SUBACK_STATUS_SUCCESS_QOS_0
+ * #MQTT_SUBACK_STATUS_SUCCESS_QOS_1
+ * #MQTT_SUBACK_STATUS_SUCCESS_QOS_2
+ * #MQTT_SUBACK_STATUS_FAILURE
  *
  * @param[in] pSubackPacket The SUBACK packet whose payload is to be parsed.
  * @param[out] pPayloadStart This is populated with the starting address

--- a/source/lexicon.txt
+++ b/source/lexicon.txt
@@ -130,7 +130,6 @@ mqttstatenull
 mqttstateoperation
 mqttstatus
 mqttsubackfailure
-mqttsubackstatus
 mqttsubacksuccessqos
 mqttsubscribeinfo
 mqttsuccess

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -2626,10 +2626,10 @@ void test_MQTT_GetSubAckStatusCodes( void )
     status = MQTT_GetSubAckStatusCodes( &mqttPacketInfo, &pPayloadStart, &payloadSize );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     TEST_ASSERT_EQUAL_PTR( &buffer[ 2 ], pPayloadStart );
-    TEST_ASSERT_EQUAL_INT( MQTTSubAckSuccessQos0, pPayloadStart[ 0 ] );
-    TEST_ASSERT_EQUAL_INT( MQTTSubAckSuccessQos1, pPayloadStart[ 1 ] );
-    TEST_ASSERT_EQUAL_INT( MQTTSubAckSuccessQos2, pPayloadStart[ 2 ] );
-    TEST_ASSERT_EQUAL_INT( MQTTSubAckFailure, pPayloadStart[ 3 ] );
+    TEST_ASSERT_EQUAL_INT( MQTT_SUBACK_STATUS_SUCCESS_QOS_0, pPayloadStart[ 0 ] );
+    TEST_ASSERT_EQUAL_INT( MQTT_SUBACK_STATUS_SUCCESS_QOS_1, pPayloadStart[ 1 ] );
+    TEST_ASSERT_EQUAL_INT( MQTT_SUBACK_STATUS_SUCCESS_QOS_2, pPayloadStart[ 2 ] );
+    TEST_ASSERT_EQUAL_INT( MQTT_SUBACK_STATUS_FAILURE, pPayloadStart[ 3 ] );
     TEST_ASSERT_EQUAL_INT( 4, payloadSize );
 
     /* Packet is NULL. */


### PR DESCRIPTION
Replace MQTTSubAckStatus_t enum with equivalent macros to address MISRA 2.3 Rule violation﻿
