### PR TITLE
Fix MISRA 10.3 violation

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1793,7 +1793,7 @@ MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
         /* Initialize keep-alive fields after a successful connection. */
         pContext->keepAliveIntervalSec = pConnectInfo->keepAliveSeconds;
         pContext->waitingForPingResp = false;
-        pContext->pingReqSendTimeMs = 0UL;
+        pContext->pingReqSendTimeMs = 0U;
     }
     else
     {


### PR DESCRIPTION
*Description*:
Fix MISRA 10.3 violation introduced in #7 due to using `UL` instead of `U`
