### PR TITLE
Hygiene changes in doxygen configuration

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "MQTT"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "LTS rc1"
+PROJECT_NUMBER         = "v202009.00"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "MQTT"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "v202009.00"
+PROJECT_NUMBER         = "v1.0.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -60,7 +60,7 @@ MQTT Library Design
 <!-- @par configpagestyle allows the @section titles to be styled according to style.css -->
 @par configpagestyle
 
-Some configuration settings are C pre-processor constants and some are function-like macros for logging. They can be set with a `\#define` in the config file (**core_mqtt_config.h**) or by using a compiler option such as -D in gcc.
+Some configuration settings are C pre-processor constants, and some are function-like macros for logging. They can be set with a `\#define` in the config file (**core_mqtt_config.h**) or by using a compiler option such as -D in gcc.
 
 @section MQTT_STATE_ARRAY_MAX_COUNT
 @copydoc MQTT_STATE_ARRAY_MAX_COUNT

--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -8,7 +8,7 @@
 This MQTT library implements the client side of the MQTT 3.1.1 protocol. This library is optimized for resource constrained embedded devices. Features of this library include:
 - Fully synchronous API, to allow applications to completely manage their concurrency and multi-threading method.
 - Operations on fixed buffers, so that applications may control their memory allocation strategy.
-- Scalable performance and footprint. The [configuration settings](@ref mqtt_config) allow this library to be tailored to a system's resources.
+- Scalable performance and footprint. The [configuration settings](@ref core_mqtt_config) allow this library to be tailored to a system's resources.
 
 Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/development/demos/mqtt for example code demonstrating integration with TLS.
 
@@ -55,35 +55,29 @@ MQTT Library Design
 */
 
 /**
-@page mqtt_config Configurations
+@page core_mqtt_config Configurations
 @brief Configurations of the MQTT Library.
 <!-- @par configpagestyle allows the @section titles to be styled according to style.css -->
 @par configpagestyle
 
-Configuration settings are C pre-processor constants. They can be set with a \#define in the config file (mqtt_config.h) or by using a compiler option such as -D in gcc.
+Some configuration settings are C pre-processor constants and some are function-like macros for logging. They can be set with a `\#define` in the config file (**core_mqtt_config.h**) or by using a compiler option such as -D in gcc.
 
 @section MQTT_STATE_ARRAY_MAX_COUNT
-<br>
 @copydoc MQTT_STATE_ARRAY_MAX_COUNT
 
 @section MQTT_PINGRESP_TIMEOUT_MS
-<br>
 @copydoc MQTT_PINGRESP_TIMEOUT_MS
 
 @section MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT
-<br>
 @copydoc MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT
 
 @section LogError
-<br>
 @copydoc LogError
 
 @section LogWarn
-<br>
 @copydoc LogWarn
 
 @section LogInfo
-<br>
 @copydoc LogInfo
 */
 

--- a/test/cbmc/proofs/MQTT_Connect/Makefile
+++ b/test/cbmc/proofs/MQTT_Connect/Makefile
@@ -31,7 +31,7 @@ MAX_NETWORK_SEND_TRIES=3
 # time out of 3 we can get coverage of the entire function. Another iteration
 # performed will unnecessarily duplicate the proof.
 MQTT_RECEIVE_TIMEOUT=3
-# Please see test/cbmc/include/mqtt_config.h for more
+# Please see test/cbmc/include/core_mqtt_config.h for more
 # information on these defines.
 MQTT_STATE_ARRAY_MAX_COUNT=11
 MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT=3
@@ -67,7 +67,7 @@ UNWINDSET += __CPROVER_file_local_core_mqtt_serializer_c_encodeRemainingLength.0
 UNWINDSET += __CPROVER_file_local_core_mqtt_serializer_c_getRemainingLength.0:5
 # This loop will run for the maximum number of publishes pending
 # acknowledgements plus one. This value is set in
-# test/cbmc/include/mqtt_config.h.
+# test/cbmc/include/core_mqtt_config.h.
 UNWINDSET += __CPROVER_file_local_core_mqtt_state_c_stateSelect.0:$(MQTT_STATE_ARRAY_MAX_COUNT)
 
 PROOF_SOURCES += $(PROOFDIR)/$(HARNESS_FILE).c

--- a/test/cbmc/proofs/MQTT_ProcessLoop/Makefile
+++ b/test/cbmc/proofs/MQTT_ProcessLoop/Makefile
@@ -31,7 +31,7 @@ MQTT_RECEIVE_TIMEOUT=3
 # Please see test/cbmc/stubs/network_interface_subs.c for
 # more information on MAX_NETWORK_SEND_TRIES.
 MAX_NETWORK_SEND_TRIES=3
-# Please see test/cbmc/include/mqtt_config.h for more
+# Please see test/cbmc/include/core_mqtt_config.h for more
 # information.
 MQTT_STATE_ARRAY_MAX_COUNT=11
 DEFINES += -DMQTT_RECEIVE_TIMEOUT=$(MQTT_RECEIVE_TIMEOUT)
@@ -58,7 +58,7 @@ UNWINDSET += __CPROVER_file_local_core_mqtt_c_sendPacket.0:$(MAX_NETWORK_SEND_TR
 UNWINDSET += __CPROVER_file_local_core_mqtt_serializer_c_getRemainingLength.0:5
 # These loops will run for the maximum number of publishes pending
 # acknowledgements plus one. This value is set in
-# test/cbmc/include/mqtt_config.h.
+# test/cbmc/include/core_mqtt_config.h.
 UNWINDSET += __CPROVER_file_local_core_mqtt_state_c_addRecord.0:$(MQTT_STATE_ARRAY_MAX_COUNT)
 UNWINDSET += __CPROVER_file_local_core_mqtt_state_c_findInRecord.0:$(MQTT_STATE_ARRAY_MAX_COUNT)
 

--- a/test/cbmc/proofs/MQTT_Publish/Makefile
+++ b/test/cbmc/proofs/MQTT_Publish/Makefile
@@ -25,7 +25,7 @@ HARNESS_FILE=MQTT_Publish_harness
 # Please see test/cbmc/stubs/network_interface_subs.c for
 # more information on MAX_NETWORK_SEND_TRIES.
 MAX_NETWORK_SEND_TRIES=3
-# Please see test/cbmc/include/mqtt_config.h for more
+# Please see test/cbmc/include/core_mqtt_config.h for more
 # information.
 MQTT_STATE_ARRAY_MAX_COUNT=11
 DEFINES += -DMAX_NETWORK_SEND_TRIES=$(MAX_NETWORK_SEND_TRIES)
@@ -40,7 +40,7 @@ REMOVE_FUNCTION_BODY +=
 # information.
 UNWINDSET += __CPROVER_file_local_core_mqtt_c_sendPacket.0:$(MAX_NETWORK_SEND_TRIES)
 # These loops will run for the maximum number of publishes pending acknowledgement.
-# This is set in test/cbmc/include/mqtt_config.h.
+# This is set in test/cbmc/include/core_mqtt_config.h.
 UNWINDSET += __CPROVER_file_local_core_mqtt_state_c_addRecord.0:$(MQTT_STATE_ARRAY_MAX_COUNT)
 UNWINDSET += __CPROVER_file_local_core_mqtt_state_c_findInRecord.0:$(MQTT_STATE_ARRAY_MAX_COUNT)
 # The encodeRemainingLength loop is unwound 5 times because encodeRemainingLength()

--- a/test/cbmc/proofs/MQTT_ReceiveLoop/Makefile
+++ b/test/cbmc/proofs/MQTT_ReceiveLoop/Makefile
@@ -13,7 +13,7 @@ MQTT_RECEIVE_TIMEOUT=3
 # Please see test/cbmc/stubs/network_interface_subs.c for
 # more information on MAX_NETWORK_SEND_TRIES.
 MAX_NETWORK_SEND_TRIES=3
-# Please see test/cbmc/include/mqtt_config.h for more
+# Please see test/cbmc/include/core_mqtt_config.h for more
 # information.
 MQTT_STATE_ARRAY_MAX_COUNT=11
 DEFINES += -DMQTT_RECEIVE_TIMEOUT=$(MQTT_RECEIVE_TIMEOUT)
@@ -39,7 +39,7 @@ UNWINDSET += __CPROVER_file_local_core_mqtt_c_sendPacket.0:$(MAX_NETWORK_SEND_TR
 # log128(SIZE_MAX) = 4.571...
 UNWINDSET += __CPROVER_file_local_core_mqtt_serializer_c_getRemainingLength.0:5
 # These loops will run for the maximum number of publishes pending acknowledgement.
-# This is set in test/cbmc/include/mqtt_config.h.
+# This is set in test/cbmc/include/core_mqtt_config.h.
 UNWINDSET += __CPROVER_file_local_core_mqtt_state_c_addRecord.0:$(MQTT_STATE_ARRAY_MAX_COUNT)
 UNWINDSET += __CPROVER_file_local_core_mqtt_state_c_findInRecord.0:$(MQTT_STATE_ARRAY_MAX_COUNT)
 


### PR DESCRIPTION
Changes include:
* Update doxygen to generate configurations page with core_mqtt_config page name
* Update library version number from "LTS rc1" to "v202009.00"
* Update comments in CBMC files to refer to core_mqtt_config.h instead of mqtt_config.h
