### PR TITLE
Update the transport_interface for multiple page and section definition warnings in the CSDK hub

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -2570,3 +2570,6 @@ DOT_CLEANUP            = YES
 
 ALIASES += transportcallback="@ingroup mqtt_callback_types"
 ALIASES += transportstruct="@ingroup mqtt_struct_types"
+ALIASES += transportpage="@page mqtt_transport_interface Transport Interface"
+ALIASES += transportsectionimplementation="@section mqtt_transport_interface_implementation Implementing the Transport Interface"
+ALIASES += transportsectionoverview="@section mqtt_transport_interface_overview Transport Interface Overview"

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -332,7 +332,10 @@ topicfilterlength
 topicnamelength
 transportcallback
 transportinterface
+transportpage
 transportrecv
+transportsectionimplementation
+transportsectionoverview
 transportsend
 transportstruct
 uint

--- a/source/portable/transport_interface.h
+++ b/source/portable/transport_interface.h
@@ -31,10 +31,10 @@
 #include <stddef.h>
 
 /**
- * @page transport_interface Transport Interface
+ * @transportpage
  * @brief The transport interface definition.
  *
- * @section transport_interface_overview Transport Interface Overview
+ * @transportsectionoverview
  *
  * The transport interface is a set of APIs that must be implemented using an
  * external transport layer protocol. The transport interface is defined in
@@ -55,7 +55,7 @@
  * @snippet this define_transportinterface
  * <br>
  *
- * @section transport_interface_implementation Implementing the Transport Interface
+ * @transportsectionimplementation
  *
  * The following steps give guidance on implementing the transport interface:
  *


### PR DESCRIPTION
The CSDK references the generated file docs/doxygen/output/mqtt.tag
This tag file contains references to all MQTT functions, variables, pages, sections, etc.. all doxygen references.
The transport_interface.h documentation had generic names for its page and section references which caused multiple warnings when the hub used the mqtt.tag file.
This commit makes the transport interface section and page references unique to the library so that multiple definition warnings do not occur in the CSDK hub.

There will be a PR in the hub repo to conform the transport_interface.h doxygen docs. 