### PR TITLE
Add anchor for CSDK doxygen to reference coreMQTT mainpage.

### DIFF
--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -1,6 +1,7 @@
 /**
 @mainpage Overview
-@brief MQTT 3.1.1 client library.
+@anchor mqtt
+@brief MQTT 3.1.1 client library
 
 > MQTT stands for MQ Telemetry Transport. It is a publish/subscribe, extremely simple and lightweight messaging protocol, designed for constrained devices and low-bandwidth, high-latency or unreliable networks. The design principles are to minimise network bandwidth and device resource requirements whilst also attempting to ensure reliability and some degree of assurance of delivery. These principles also turn out to make the protocol ideal of the emerging "machine-to-machine" (M2M) or "Internet of Things" world of connected devices, and for mobile applications where bandwidth and battery power are at a premium.
 <span style="float:right;margin-right:4em"> &mdash; <i>Official description of MQTT from [mqtt.org](http://mqtt.org)</i></span><br>


### PR DESCRIPTION
The title says it all.