### PR TITLE
Update MISRA doc for 2.3 change

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -10,6 +10,7 @@ Deviations from the MISRA standard are listed below:
 | Directive 4.5 | Advisory | Allow names that MISRA considers ambiguous (such as LogInfo and LogError) |
 | Directive 4.8 | Advisory | Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file. |
 | Directive 4.9 | Advisory | Allow inclusion of function like macros. The `assert` macro is used throughout the library for parameter validation, and logging is done using function like macros. |
+| Rule 2.3 | Advisory | Allow unused types. The `MQTTSubAckStatus_t` enum is unused in our source files, as it is intended for a user to use when parsing a subscription acknowledgment's response codes. |
 | Rule 2.4 | Advisory | Allow unused tags. Some compilers warn if types are not tagged. |
 | Rule 2.5 | Advisory | Allow unused macros. Library headers may define macros intended for the application's use, but are not used by a specific file. |
 | Rule 3.1 | Required | Allow nested comments. C++ style `//` comments are used in example code within Doxygen documentation blocks. |
@@ -20,7 +21,6 @@ Deviations from the MISRA standard are listed below:
 ### Flagged by Coverity
 | Deviation | Category | Justification |
 | :-: | :-: | :-: |
-| Rule 2.3 | Advisory | The `MQTTSubAckStatus_t` enum is unused in our source files, as it is intended for a user to use when parsing a subscription acknowledgment's response codes. |
 | Rule 8.7 | Advisory | API functions are not used by the library outside of the files they are defined; however, they must be externally visible in order to be used by an application. |
 
 ### Suppressed with Coverity Comments


### PR DESCRIPTION
*Description*:
Updates MISRA doc to move the 2.3 violation from the "Flagged" to the "Ignored" section since https://github.com/aws/aws-iot-device-sdk-embedded-C/pull/1235 was merged
