### PR TITLE
Use MQTT specific anchors for generic targets

### DIFF
--- a/docs/doxygen/pages.txt
+++ b/docs/doxygen/pages.txt
@@ -11,7 +11,7 @@ This MQTT library implements the client side of the MQTT 3.1.1 protocol. This li
 - Operations on fixed buffers, so that applications may control their memory allocation strategy.
 - Scalable performance and footprint. The [configuration settings](@ref core_mqtt_config) allow this library to be tailored to a system's resources.
 
-Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/development/demos/mqtt for example code demonstrating integration with TLS.
+Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/demos/mqtt for example code demonstrating integration with TLS.
 
 @section mqtt_memory_requirements Memory Requirements
 @brief Memory requirements of the MQTT library.
@@ -188,16 +188,16 @@ Some configuration settings are C pre-processor constants, and some are function
 @section MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT
 @copydoc MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT
 
-@section LogError
+@section mqtt_logerror LogError
 @copydoc LogError
 
-@section LogWarn
+@section mqtt_logwarn LogWarn
 @copydoc LogWarn
 
-@section LogInfo
+@section mqtt_loginfo LogInfo
 @copydoc LogInfo
 
-@section LogDebug
+@section mqtt_logdebug LogDebug
 @copydoc LogDebug
 */
 

--- a/docs/doxygen/porting.txt
+++ b/docs/doxygen/porting.txt
@@ -3,11 +3,11 @@
 @brief Guide for porting MQTT to a new platform.
 
 A port to a new platform must provide the following components:
-1. [Configuration Macros](@ref porting_config)
-2. [Transport Interface](@ref porting_transport)
-3. [Time Function](@ref porting_time)
+1. [Configuration Macros](@ref mqtt_porting_config)
+2. [Transport Interface](@ref mqtt_porting_transport)
+3. [Time Function](@ref mqtt_porting_time)
 
-@section porting_config Configuration Macros
+@section mqtt_porting_config Configuration Macros
 @brief Settings that must be set as macros in the config header `core_mqtt_config.h`, or passed in as compiler options.
 
 @note If a custom configuration header `core_mqtt_config.h` is not provided, then the @ref MQTT_DO_NOT_USE_CUSTOM_CONFIG macro must be defined.
@@ -25,7 +25,7 @@ In addition, the following logging macros are used throughout the library:
  - @ref LogInfo
  - @ref LogDebug
 
-@section porting_transport Transport Interface
+@section mqtt_porting_transport Transport Interface
 @brief The MQTT library relies on an underlying transport interface API that must be implemented
 in order to send and receive packets on a network.
 
@@ -56,7 +56,7 @@ struct NetworkContext {
 };
 @endcode
 
-@section porting_time Time Function
+@section mqtt_porting_time Time Function
 @brief The MQTT library relies on a function to generate millisecond timestamps, for the
 purpose of calculating durations and timeouts, as well as maintaining the keep-alive mechanism
 of the MQTT protocol.


### PR DESCRIPTION
*Description*:
Adds `mqtt_` prefix to anchors in porting guide and configuration page, to avoid possible collisions with other libraries.
