### PR TITLE
Update code sizes

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -29,23 +29,23 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td>3.3K</td>
-        <td>2.9K</td>
+        <td>6.9K</td>
+        <td>6.3K</td>
     </tr>
     <tr>
         <td>core_mqtt_state.c</td>
-        <td>2.1K</td>
-        <td>1.6K</td>
+        <td>3.0K</td>
+        <td>2.3K</td>
     </tr>
     <tr>
         <td>core_mqtt_serializer.c</td>
-        <td>3.5K</td>
-        <td>2.9K</td>
+        <td>5.6K</td>
+        <td>5.1K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>8.9K</td>
-        <td>7.4K</td>
+        <td>15.5K</td>
+        <td>13.7K</td>
     </tr>
 </table>
  */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -29,23 +29,23 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td>6.9K</td>
-        <td>6.3K</td>
+        <td>6.7K</td>
+        <td>6.2K</td>
     </tr>
     <tr>
         <td>core_mqtt_state.c</td>
-        <td>3.0K</td>
+        <td>2.9K</td>
         <td>2.3K</td>
     </tr>
     <tr>
         <td>core_mqtt_serializer.c</td>
-        <td>5.6K</td>
-        <td>5.1K</td>
+        <td>5.5K</td>
+        <td>4.9K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>15.5K</td>
-        <td>13.7K</td>
+        <td>15.1K</td>
+        <td>13.4K</td>
     </tr>
 </table>
  */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -24,9 +24,9 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>No Optimisation (asserts enabled)</b></td>
-        <td><b>With -O1 Optimisation (asserts disabled)</b></td>
-        <td><b>With -Os Optimisation (asserts disabled)</b></td>
+        <td><b>No Optimization (asserts enabled)</b></td>
+        <td><b>With -O1 Optimization (asserts disabled)</b></td>
+        <td><b>With -Os Optimization (asserts disabled)</b></td>
     </tr>
     <tr>
         <td>core_mqtt.c</td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -24,23 +24,27 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>With -O1 Optimization</b></td>
-        <td><b>With -Os Optimization</b></td>
+        <td><b>No Optimisation (asserts enabled)</b></td>
+        <td><b>With -O1 Optimisation (asserts disabled)</b></td>
+        <td><b>With -Os Optimisation (asserts disabled)</b></td>
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td>6.7K</td>
-        <td>6.2K</td>
+        <td>13.3K</td>
+        <td>5.1K</td>
+        <td>4.6K</td>
     </tr>
     <tr>
         <td>core_mqtt_state.c</td>
-        <td>2.9K</td>
-        <td>2.3K</td>
+        <td>5.9K</td>
+        <td>2.2K</td>
+        <td>1.8K</td>
     </tr>
     <tr>
         <td>core_mqtt_serializer.c</td>
-        <td>5.5K</td>
-        <td>4.9K</td>
+        <td>12.0K</td>
+        <td>4.2K</td>
+        <td>3.7K</td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -20,7 +20,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="3"><b>Code Size of coreMQTT (example generated with GCC for ARM Cortex-M)</b></td>
+        <td colspan="4"><center><b>Code Size of coreMQTT library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -20,7 +20,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="3"><b>Code Size of MQTT LTS rc1(example generated with GCC for ARM Cortex-M)</b></td>
+        <td colspan="3"><b>Code Size of coreMQTT (example generated with GCC for ARM Cortex-M)</b></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -20,7 +20,7 @@ The configurations for memory estimation are defined <a href="https://github.com
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code Size of coreMQTT library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads))</b></center></td>
+        <td colspan="4"><center><b>Code Size of coreMQTT library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2019-q4-major))</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -48,8 +48,9 @@ The configurations for memory estimation are defined <a href="https://github.com
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>15.1K</td>
-        <td>13.4K</td>
+        <td>31.2K</td>
+        <td>11.5K</td>
+        <td>10.1K</td>
     </tr>
 </table>
  */


### PR DESCRIPTION
I calculated code sizes after adding version numbers in PR #53 

**Note: I am always rounding up.**

O0:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
  13577       0       0   13577    3509 core_mqtt.c.obj (ex libcoverity_analysis.a)
   5979       0       0    5979    175b core_mqtt_state.c.obj (ex libcoverity_analysis.a)
  12203       0       0   12203    2fab core_mqtt_serializer.c.obj (ex libcoverity_analysis.a)
  31759       0       0   31759    7c0f (TOTALS)
```
O1:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
   5145       0       0    5145    1419 core_mqtt.c.obj (ex libcoverity_analysis.a)
   2236       0       0    2236     8bc core_mqtt_state.c.obj (ex libcoverity_analysis.a)
   4213       0       0    4213    1075 core_mqtt_serializer.c.obj (ex libcoverity_analysis.a)
  11594       0       0   11594    2d4a (TOTALS)
```
Os:
size -t libcoverity_analysis.a
```
   text    data     bss     dec     hex filename
   4624       0       0    4624    1210 core_mqtt.c.obj (ex libcoverity_analysis.a)
   1779       0       0    1779     6f3 core_mqtt_state.c.obj (ex libcoverity_analysis.a)
   3772       0       0    3772     ebc core_mqtt_serializer.c.obj (ex libcoverity_analysis.a)
  10175       0       0   10175    27bf (TOTALS)
```