### PR TITLE
Fix coverity analysis target to include serializer file

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,8 @@ include( ${MODULE_ROOT_DIR}/mqttFilePaths.cmake )
 
 # Target for Coverity analysis that builds the library.
 add_library( coverity_analysis
-             ${MQTT_SOURCES} )
+             ${MQTT_SOURCES}
+             ${MQTT_SERIALIZER_SOURCES} )
 
 # Build MQTT library target without custom config dependency.
 target_compile_definitions( coverity_analysis PUBLIC MQTT_DO_NOT_USE_CUSTOM_CONFIG=1 )


### PR DESCRIPTION
The MQTT serializer file was not included in the build of the `coverity_analysis` target.

This PR update the target to build the serializer file so that all library sources are included in the library..
