### PR TITLE
Delete irrelevant comment about memory estimation.

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "coreMQTT"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "V1.0.0"
+PROJECT_NUMBER         = "v1.0.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -32,13 +32,13 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "MQTT"
+PROJECT_NAME           = "coreMQTT"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "v1.0.0"
+PROJECT_NUMBER         = "V1.0.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -16,8 +16,6 @@ Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/master/demo
 @section mqtt_memory_requirements Memory Requirements
 @brief Memory requirements of the MQTT library.
 
-The configurations for memory estimation are defined <a href="https://github.com/FreeRTOS/FreeRTOS/tree/lts-development/tools/memory_estimator" target="_blank" rel="noopener noreferrer">here</a>.
-
 <table>
     <tr>
         <td colspan="4"><center><b>Code Size of coreMQTT library files (sizes generated with [GCC for ARM Cortex-M toolchain 20191025](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2019-q4-major))</b></center></td>


### PR DESCRIPTION
- The memory estimation was found using the ARM tools directly and the comment above does not make sense for the documentation.
- Update the name of the library and the version to match what is in the license of the source files.
