### PR TITLE
Set NULL payloads and fix unit test

### DIFF
--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -1298,7 +1298,7 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket
         }
 
         /* Set payload if it exists. */
-        pPublishInfo->pPayload = ( pPublishInfo->payloadLength != 0 ) ? pPacketIdentifierHigh : NULL;
+        pPublishInfo->pPayload = ( pPublishInfo->payloadLength != 0U ) ? pPacketIdentifierHigh : NULL;
 
         LogDebug( ( "Payload length %lu.", ( unsigned long ) pPublishInfo->payloadLength ) );
     }

--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -1274,6 +1274,9 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket
 
             LogDebug( ( "Packet identifier %hu.", *pPacketId ) );
 
+            /* Advance pointer two bytes to start of payload as in the QoS 0 case. */
+            pPacketIdentifierHigh += sizeof( uint16_t );
+
             /* Packet identifier cannot be 0. */
             if( *pPacketId == 0U )
             {
@@ -1286,16 +1289,16 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket
     {
         /* Calculate the length of the payload. QoS 1 or 2 PUBLISH packets contain
          * a packet identifier, but QoS 0 PUBLISH packets do not. */
-        if( pPublishInfo->qos == MQTTQoS0 )
+        pPublishInfo->payloadLength = pIncomingPacket->remainingLength - pPublishInfo->topicNameLength - sizeof( uint16_t );
+
+        if( pPublishInfo->qos != MQTTQoS0 )
         {
-            pPublishInfo->payloadLength = ( pIncomingPacket->remainingLength - pPublishInfo->topicNameLength - sizeof( uint16_t ) );
-            pPublishInfo->pPayload = pPacketIdentifierHigh;
+            /* Two more bytes for the packet identifier. */
+            pPublishInfo->payloadLength -= sizeof( uint16_t );
         }
-        else
-        {
-            pPublishInfo->payloadLength = ( pIncomingPacket->remainingLength - pPublishInfo->topicNameLength - 2U * sizeof( uint16_t ) );
-            pPublishInfo->pPayload = pPacketIdentifierHigh + sizeof( uint16_t );
-        }
+
+        /* Set payload if it exists. */
+        pPublishInfo->pPayload = ( pPublishInfo->payloadLength != 0 ) ? pPacketIdentifierHigh : NULL;
 
         LogDebug( ( "Payload length %lu.", ( unsigned long ) pPublishInfo->payloadLength ) );
     }

--- a/test/unit-test/core_mqtt_serializer_utest.c
+++ b/test/unit-test/core_mqtt_serializer_utest.c
@@ -75,20 +75,14 @@
 #define MQTT_TEST_PASSWORD_LEN              ( sizeof( MQTT_TEST_PASSWORD ) - 1 )
 
 /**
- * @brief Test-defined macro for MQTT topic.
- */
-#define MQTT_TEST_TOPIC                     "topic"
-#define MQTT_TEST_TOPIC_LEN                 ( sizeof( MQTT_TEST_TOPIC ) - 1 )
-
-/**
  * @brief Length of the client identifier.
  */
 #define MQTT_CLIENT_IDENTIFIER_LEN          ( sizeof( MQTT_CLIENT_IDENTIFIER ) - 1 )
 
 /**
- * @brief Payload for will info.
+ * @brief Sample payload.
  */
-#define MQTT_SAMPLE_PAYLOAD                 "payload"
+#define MQTT_SAMPLE_PAYLOAD                 "Hello World"
 #define MQTT_SAMPLE_PAYLOAD_LEN             ( sizeof( MQTT_SAMPLE_PAYLOAD ) - 1 )
 
 /* MQTT CONNECT flags. */
@@ -1660,10 +1654,10 @@ void test_MQTT_DeserializePublish( void )
 
     /* Create a PUBLISH packet to test. */
     memset( &publishInfo, 0x00, sizeof( publishInfo ) );
-    publishInfo.pTopicName = "/test/topic";
-    publishInfo.topicNameLength = ( uint16_t ) strlen( publishInfo.pTopicName );
-    publishInfo.pPayload = "Hello World";
-    publishInfo.payloadLength = ( uint16_t ) strlen( publishInfo.pPayload );
+    publishInfo.pTopicName = TEST_TOPIC_NAME;
+    publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
+    publishInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
+    publishInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
 
     /* Test serialization and deserialization of a QoS 0 PUBLISH. */
     publishInfo.qos = MQTTQoS0;
@@ -1688,8 +1682,18 @@ void test_MQTT_DeserializePublish( void )
     mqttPacketInfo.pRemainingData = &buffer[ 2 ];
     status = MQTT_DeserializePublish( &mqttPacketInfo, &packetIdentifier, &publishInfo );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
+    TEST_ASSERT_EQUAL_INT( TEST_TOPIC_NAME_LENGTH, publishInfo.topicNameLength );
+    TEST_ASSERT_EQUAL_MEMORY( TEST_TOPIC_NAME, publishInfo.pTopicName, TEST_TOPIC_NAME_LENGTH );
+    TEST_ASSERT_EQUAL_INT( MQTT_SAMPLE_PAYLOAD_LEN, publishInfo.payloadLength );
+    TEST_ASSERT_EQUAL_MEMORY( MQTT_SAMPLE_PAYLOAD, publishInfo.pPayload, MQTT_SAMPLE_PAYLOAD_LEN );
 
     memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    /* Reset publish info since its pointers now point to our serialized buffer. */
+    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
+    publishInfo.pTopicName = TEST_TOPIC_NAME;
+    publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
+    publishInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
+    publishInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
 
     /* Test serialization and deserialization of a QoS 1 PUBLISH. */
     publishInfo.qos = MQTTQoS1;
@@ -1711,8 +1715,17 @@ void test_MQTT_DeserializePublish( void )
     status = MQTT_DeserializePublish( &mqttPacketInfo, &packetIdentifier, &publishInfo );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     TEST_ASSERT_TRUE( publishInfo.dup );
+    TEST_ASSERT_EQUAL_INT( TEST_TOPIC_NAME_LENGTH, publishInfo.topicNameLength );
+    TEST_ASSERT_EQUAL_MEMORY( TEST_TOPIC_NAME, publishInfo.pTopicName, TEST_TOPIC_NAME_LENGTH );
+    TEST_ASSERT_EQUAL_INT( MQTT_SAMPLE_PAYLOAD_LEN, publishInfo.payloadLength );
+    TEST_ASSERT_EQUAL_MEMORY( MQTT_SAMPLE_PAYLOAD, publishInfo.pPayload, MQTT_SAMPLE_PAYLOAD_LEN );
 
     /* QoS 2 PUBLISH. */
+    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
+    publishInfo.pTopicName = TEST_TOPIC_NAME;
+    publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
+    publishInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
+    publishInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
     publishInfo.qos = MQTTQoS2;
     /* Remaining length and packet size should be same as before. */
     status = MQTT_SerializePublish( &publishInfo,
@@ -1725,6 +1738,10 @@ void test_MQTT_DeserializePublish( void )
     mqttPacketInfo.pRemainingData = &buffer[ 2 ];
     status = MQTT_DeserializePublish( &mqttPacketInfo, &packetIdentifier, &publishInfo );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
+    TEST_ASSERT_EQUAL_INT( TEST_TOPIC_NAME_LENGTH, publishInfo.topicNameLength );
+    TEST_ASSERT_EQUAL_MEMORY( TEST_TOPIC_NAME, publishInfo.pTopicName, TEST_TOPIC_NAME_LENGTH );
+    TEST_ASSERT_EQUAL_INT( MQTT_SAMPLE_PAYLOAD_LEN, publishInfo.payloadLength );
+    TEST_ASSERT_EQUAL_MEMORY( MQTT_SAMPLE_PAYLOAD, publishInfo.pPayload, MQTT_SAMPLE_PAYLOAD_LEN );
 
     /* Zero length payload. */
     memset( &publishInfo, 0x00, sizeof( publishInfo ) );
@@ -1752,7 +1769,7 @@ void test_MQTT_DeserializePublish( void )
     status = MQTT_DeserializePublish( &mqttPacketInfo, &packetIdentifier, &publishInfo );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     TEST_ASSERT_EQUAL_INT( TEST_TOPIC_NAME_LENGTH, publishInfo.topicNameLength );
-    TEST_ASSERT_EQUAL_STRING( TEST_TOPIC_NAME, publishInfo.pTopicName );
+    TEST_ASSERT_EQUAL_MEMORY( TEST_TOPIC_NAME, publishInfo.pTopicName, TEST_TOPIC_NAME_LENGTH );
     TEST_ASSERT_EQUAL_INT( 0, publishInfo.payloadLength );
     TEST_ASSERT_NULL( publishInfo.pPayload );
 }

--- a/test/unit-test/core_mqtt_serializer_utest.c
+++ b/test/unit-test/core_mqtt_serializer_utest.c
@@ -284,19 +284,19 @@ static void setupConnectInfo( MQTTConnectInfo_t * const pConnectInfo )
 }
 
 /**
- * @brief Initialize pWillInfo using test-defined macros.
+ * @brief Initialize pPublishInfo using test-defined macros.
  *
- * @param[in] pWillInfo Last Will and Testament.
+ * @param[in] pPublishInfo Publish information.
  */
-static void setupWillInfo( MQTTPublishInfo_t * const pWillInfo )
+static void setupPublishInfo( MQTTPublishInfo_t * pPublishInfo )
 {
-    pWillInfo->pPayload = MQTT_SAMPLE_PAYLOAD;
-    pWillInfo->payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
-    pWillInfo->pTopicName = MQTT_CLIENT_IDENTIFIER;
-    pWillInfo->topicNameLength = MQTT_CLIENT_IDENTIFIER_LEN;
-    pWillInfo->dup = true;
-    pWillInfo->qos = MQTTQoS0;
-    pWillInfo->retain = true;
+    pPublishInfo->pTopicName = TEST_TOPIC_NAME;
+    pPublishInfo->topicNameLength = TEST_TOPIC_NAME_LENGTH;
+    pPublishInfo->pPayload = MQTT_SAMPLE_PAYLOAD;
+    pPublishInfo->payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
+    pPublishInfo->qos = MQTTQoS0;
+    pPublishInfo->dup = false;
+    pPublishInfo->retain = false;
 }
 
 /**
@@ -1654,10 +1654,7 @@ void test_MQTT_DeserializePublish( void )
 
     /* Create a PUBLISH packet to test. */
     memset( &publishInfo, 0x00, sizeof( publishInfo ) );
-    publishInfo.pTopicName = TEST_TOPIC_NAME;
-    publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
-    publishInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
-    publishInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
+    setupPublishInfo( &publishInfo );
 
     /* Test serialization and deserialization of a QoS 0 PUBLISH. */
     publishInfo.qos = MQTTQoS0;
@@ -1689,11 +1686,7 @@ void test_MQTT_DeserializePublish( void )
 
     memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
     /* Reset publish info since its pointers now point to our serialized buffer. */
-    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
-    publishInfo.pTopicName = TEST_TOPIC_NAME;
-    publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
-    publishInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
-    publishInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
+    setupPublishInfo( &publishInfo );
 
     /* Test serialization and deserialization of a QoS 1 PUBLISH. */
     publishInfo.qos = MQTTQoS1;
@@ -1721,11 +1714,7 @@ void test_MQTT_DeserializePublish( void )
     TEST_ASSERT_EQUAL_MEMORY( MQTT_SAMPLE_PAYLOAD, publishInfo.pPayload, MQTT_SAMPLE_PAYLOAD_LEN );
 
     /* QoS 2 PUBLISH. */
-    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
-    publishInfo.pTopicName = TEST_TOPIC_NAME;
-    publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
-    publishInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
-    publishInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
+    setupPublishInfo( &publishInfo );
     publishInfo.qos = MQTTQoS2;
     /* Remaining length and packet size should be same as before. */
     status = MQTT_SerializePublish( &publishInfo,
@@ -2332,7 +2321,9 @@ void test_MQTT_SerializeConnect_Happy_Paths()
     /* Fill structs to pass into methods to be tested. */
     setupNetworkBuffer( &networkBuffer );
     setupConnectInfo( &connectInfo );
-    setupWillInfo( &willInfo );
+    setupPublishInfo( &willInfo );
+    willInfo.dup = true;
+    willInfo.retain = true;
 
     /* Get MQTT connect packet size and remaining length. */
     mqttStatus = MQTT_GetConnectPacketSize( &connectInfo,

--- a/test/unit-test/core_mqtt_serializer_utest.c
+++ b/test/unit-test/core_mqtt_serializer_utest.c
@@ -396,7 +396,7 @@ static void padAndResetBuffer( uint8_t * pBuffer,
     }
 
     /* Zero out rest of buffer. */
-    memset( ( void * ) &pBuffer[ BUFFER_PADDING_LENGTH ], 0x0, bufferLength - 2 * BUFFER_PADDING_LENGTH );
+    memset( &pBuffer[ BUFFER_PADDING_LENGTH ], 0x0, bufferLength - 2 * BUFFER_PADDING_LENGTH );
 }
 
 /**
@@ -444,7 +444,7 @@ void test_MQTT_GetConnectPacketSize( void )
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
     /* Verify empty connect info fails. */
-    memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
+    memset( &connectInfo, 0x0, sizeof( connectInfo ) );
     status = MQTT_GetConnectPacketSize( &connectInfo, NULL, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
@@ -460,7 +460,7 @@ void test_MQTT_GetConnectPacketSize( void )
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
     /* Test a will message payload length that is too large. */
-    memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
+    memset( &connectInfo, 0x0, sizeof( connectInfo ) );
     connectInfo.pClientIdentifier = CLIENT_IDENTIFIER;
     connectInfo.clientIdentifierLength = UINT16_MAX;
     connectInfo.pPassword = "";
@@ -475,7 +475,7 @@ void test_MQTT_GetConnectPacketSize( void )
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
     /* Verify good case */
-    memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
+    memset( &connectInfo, 0x0, sizeof( connectInfo ) );
     connectInfo.cleanSession = true;
     connectInfo.pClientIdentifier = "TEST";
     connectInfo.clientIdentifierLength = 4;
@@ -488,7 +488,7 @@ void test_MQTT_GetConnectPacketSize( void )
 
     /* With will. These parameters will cause the packet to be
      * 4 + 2 + 8 + 2 = 16 bytes larger. */
-    memset( ( void * ) &willInfo, 0x0, sizeof( willInfo ) );
+    memset( &willInfo, 0x0, sizeof( willInfo ) );
     willInfo.pTopicName = "test";
     willInfo.topicNameLength = 4;
     willInfo.pPayload = "testload";
@@ -534,17 +534,17 @@ void test_MQTT_SerializeConnect( void )
     status = MQTT_SerializeConnect( &connectInfo, &willInfo, remainingLength, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
+    memset( &connectInfo, 0x0, sizeof( connectInfo ) );
     status = MQTT_SerializeConnect( &connectInfo, NULL, 120, &fixedBuffer );
     TEST_ASSERT_EQUAL_INT( MQTTNoMemory, status );
 
     /* Create a good connection info. */
-    memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
+    memset( &connectInfo, 0x0, sizeof( connectInfo ) );
     connectInfo.pClientIdentifier = "TEST";
     connectInfo.clientIdentifierLength = 4;
 
     /* Inject a invalid fixed buffer test with a good connectInfo. */
-    memset( ( void * ) &fixedBuffer, 0x0, sizeof( fixedBuffer ) );
+    memset( &fixedBuffer, 0x0, sizeof( fixedBuffer ) );
     status = MQTT_SerializeConnect( &connectInfo, NULL, remainingLength, &fixedBuffer );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
@@ -685,7 +685,7 @@ void test_MQTT_GetSubscribePacketSize( void )
 
 
     /* Verify empty subscription list fails.  */
-    memset( ( void * ) &subscriptionList, 0x0, sizeof( subscriptionList ) );
+    memset( &subscriptionList, 0x0, sizeof( subscriptionList ) );
     subscriptionCount = 0;
     status = MQTT_GetSubscribePacketSize( &subscriptionList,
                                           subscriptionCount,
@@ -711,7 +711,7 @@ void test_MQTT_GetSubscribePacketSize( void )
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
     /* Verify good case. */
-    memset( ( void * ) &subscriptionList, 0x0, sizeof( subscriptionList ) );
+    memset( &subscriptionList, 0x0, sizeof( subscriptionList ) );
     subscriptionList.qos = MQTTQoS0;
     subscriptionList.pTopicFilter = "/example/topic";
     subscriptionList.topicFilterLength = sizeof( "/example/topic" );
@@ -759,7 +759,7 @@ void test_MQTT_GetUnsubscribePacketSize( void )
 
 
     /* Verify empty subscription list fails.  */
-    memset( ( void * ) &subscriptionList, 0x0, sizeof( subscriptionList ) );
+    memset( &subscriptionList, 0x0, sizeof( subscriptionList ) );
     subscriptionCount = 0;
     status = MQTT_GetUnsubscribePacketSize( &subscriptionList,
                                             subscriptionCount,
@@ -785,7 +785,7 @@ void test_MQTT_GetUnsubscribePacketSize( void )
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
     /* Verify good case. */
-    memset( ( void * ) &subscriptionList, 0x0, sizeof( subscriptionList ) );
+    memset( &subscriptionList, 0x0, sizeof( subscriptionList ) );
     subscriptionList.qos = MQTTQoS0;
     subscriptionList.pTopicFilter = "/example/topic";
     subscriptionList.topicFilterLength = sizeof( "/example/topic" );
@@ -851,7 +851,7 @@ void test_MQTT_SerializeSubscribe( void )
     fixedBuffer.pBuffer = &buffer[ BUFFER_PADDING_LENGTH ];
 
     /* Get correct values of packet size and remaining length. */
-    memset( ( void * ) &subscriptionList, 0x0, sizeof( subscriptionList ) );
+    memset( &subscriptionList, 0x0, sizeof( subscriptionList ) );
     subscriptionList.qos = MQTTQoS0;
     subscriptionList.pTopicFilter = "/example/topic";
     subscriptionList.topicFilterLength = sizeof( "/example/topic" );
@@ -958,7 +958,7 @@ void test_MQTT_SerializeUnsubscribe( void )
     fixedBuffer.pBuffer = &buffer[ BUFFER_PADDING_LENGTH ];
 
     /* Get correct values of packetsize and remaining length. */
-    memset( ( void * ) &subscriptionList, 0x0, sizeof( subscriptionList ) );
+    memset( &subscriptionList, 0x0, sizeof( subscriptionList ) );
     subscriptionList.qos = MQTTQoS0;
     subscriptionList.pTopicFilter = "/example/topic";
     subscriptionList.topicFilterLength = sizeof( "/example/topic" );
@@ -1035,7 +1035,7 @@ void test_MQTT_GetPublishPacketSize( void )
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
     /* Empty topic must fail. */
-    memset( ( void * ) &publishInfo, 0x00, sizeof( publishInfo ) );
+    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
     publishInfo.pTopicName = NULL;
     publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
     status = MQTT_GetPublishPacketSize( &publishInfo, &remainingLength, &packetSize );
@@ -1047,7 +1047,7 @@ void test_MQTT_GetPublishPacketSize( void )
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
     /* Packet too large. */
-    memset( ( void * ) &publishInfo, 0x00, sizeof( publishInfo ) );
+    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
     publishInfo.pTopicName = "/test/topic";
     publishInfo.topicNameLength = sizeof( "/test/topic" );
     publishInfo.payloadLength = MQTT_MAX_REMAINING_LENGTH;
@@ -1092,7 +1092,7 @@ void test_MQTT_SerializePublish( void )
                              "/test/topic/name/longer/than/one/hundred/twenty/eight/characters";
 
     /* Verify bad parameters fail. */
-    memset( ( void * ) &publishInfo, 0x00, sizeof( publishInfo ) );
+    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
     publishInfo.pTopicName = "/test/topic";
     publishInfo.topicNameLength = sizeof( "/test/topic" );
 
@@ -1218,7 +1218,7 @@ void test_MQTT_SerializePublish( void )
     publishInfo.topicNameLength = strlen( longTopic );
     publishInfo.pPayload = MQTT_SAMPLE_PAYLOAD;
     publishInfo.payloadLength = MQTT_SAMPLE_PAYLOAD_LEN;
-    memset( ( void * ) buffer, 0x00, bufferSize );
+    memset( buffer, 0x00, bufferSize );
     /* Calculate exact packet size and remaining length. */
     status = MQTT_GetPublishPacketSize( &publishInfo, &remainingLength, &packetSize );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
@@ -1231,7 +1231,7 @@ void test_MQTT_SerializePublish( void )
                                     &fixedBuffer );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
     checkBufferOverflow( buffer, sizeof( buffer ) );
-    memset( ( void * ) expectedPacket, 0x00, sizeof( expectedPacket ) );
+    memset( expectedPacket, 0x00, sizeof( expectedPacket ) );
     pIterator = expectedPacket;
     /* Set the flags as follows: Dup = 0x8, QoS2 = 0x4, Retain = 0x1. 8 | 4 | 1 = 0xD. */
     *pIterator++ = MQTT_PACKET_TYPE_PUBLISH | 0xD;
@@ -1359,7 +1359,7 @@ void test_MQTT_DeserializeAck_connack( void )
     uint8_t buffer[ 10 ];
 
     /* Verify parameters */
-    memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    memset( &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
     mqttPacketInfo.type = MQTT_PACKET_TYPE_CONNACK;
     status = MQTT_DeserializeAck( NULL, &packetIdentifier, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
@@ -1367,7 +1367,7 @@ void test_MQTT_DeserializeAck_connack( void )
     status = MQTT_DeserializeAck( &mqttPacketInfo, &packetIdentifier, NULL );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
-    memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    memset( &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
     status = MQTT_DeserializeAck( &mqttPacketInfo, &packetIdentifier, &sessionPresent );
     TEST_ASSERT_EQUAL( MQTTBadParameter, status );
 
@@ -1507,7 +1507,7 @@ void test_MQTT_DeserializeAck_pingresp( void )
     MQTTStatus_t status = MQTTSuccess;
 
     /* Bad remaining length. */
-    ( void ) memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    ( void ) memset( &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
     mqttPacketInfo.type = MQTT_PACKET_TYPE_PINGRESP;
     mqttPacketInfo.remainingLength = MQTT_PACKET_PINGRESP_REMAINING_LENGTH + 1;
     status = MQTT_DeserializeAck( &mqttPacketInfo, &packetIdentifier, &sessionPresent );
@@ -1533,7 +1533,7 @@ void test_MQTT_DeserializeAck_puback( void )
     uint8_t buffer[ 10 ] = { 0 };
 
     /* Verify parameters */
-    memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    memset( &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
     mqttPacketInfo.type = MQTT_PACKET_TYPE_PUBACK;
     status = MQTT_DeserializeAck( NULL, &packetIdentifier, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
@@ -1605,7 +1605,7 @@ void test_MQTT_DeserializePublish( void )
 
     const uint16_t PACKET_ID = 1;
 
-    memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    memset( &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
 
     /* Verify parameters. */
     status = MQTT_DeserializePublish( NULL, &packetIdentifier, &publishInfo );
@@ -1684,7 +1684,7 @@ void test_MQTT_DeserializePublish( void )
     TEST_ASSERT_EQUAL_INT( MQTT_SAMPLE_PAYLOAD_LEN, publishInfo.payloadLength );
     TEST_ASSERT_EQUAL_MEMORY( MQTT_SAMPLE_PAYLOAD, publishInfo.pPayload, MQTT_SAMPLE_PAYLOAD_LEN );
 
-    memset( ( void * ) &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
+    memset( &mqttPacketInfo, 0x00, sizeof( mqttPacketInfo ) );
     /* Reset publish info since its pointers now point to our serialized buffer. */
     setupPublishInfo( &publishInfo );
 
@@ -1888,7 +1888,7 @@ void test_MQTT_SerializePublishHeader( void )
     const uint16_t PACKET_ID = 1;
 
     /* Verify bad parameters fail. */
-    memset( ( void * ) &publishInfo, 0x00, sizeof( publishInfo ) );
+    memset( &publishInfo, 0x00, sizeof( publishInfo ) );
     publishInfo.pTopicName = TEST_TOPIC_NAME;
     publishInfo.topicNameLength = TEST_TOPIC_NAME_LENGTH;
     status = MQTT_SerializePublishHeader( NULL,
@@ -1994,7 +1994,7 @@ void test_MQTT_SerializePublishHeader( void )
      * Topic name (variable)
      * Packet ID (if QoS > 0) (1 byte)
      * Payload (>= 0 bytes) */
-    memset( ( void * ) expectedPacket, 0x00, sizeof( expectedPacket ) );
+    memset( expectedPacket, 0x00, sizeof( expectedPacket ) );
     pIterator = expectedPacket;
     *pIterator++ = MQTT_PACKET_TYPE_PUBLISH | ( publishInfo.qos << 1 );
     pIterator += encodeRemainingLength( pIterator, remainingLength );
@@ -2016,7 +2016,7 @@ void test_MQTT_SerializePublishHeader( void )
                                           &fixedBuffer,
                                           &headerSize );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
-    memset( ( void * ) expectedPacket, 0x00, sizeof( expectedPacket ) );
+    memset( expectedPacket, 0x00, sizeof( expectedPacket ) );
     pIterator = expectedPacket;
     *pIterator++ = MQTT_PACKET_TYPE_PUBLISH;
     pIterator += encodeRemainingLength( pIterator, remainingLength );
@@ -2039,7 +2039,7 @@ void test_MQTT_SerializePublishHeader( void )
                                           &headerSize );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
 
-    memset( ( void * ) expectedPacket, 0x00, sizeof( expectedPacket ) );
+    memset( expectedPacket, 0x00, sizeof( expectedPacket ) );
     pIterator = expectedPacket;
     /* Set the flags as follows: Dup = 0x8, QoS2 = 0x4, 8 | 4 = 0xC. */
     *pIterator++ = MQTT_PACKET_TYPE_PUBLISH | 0xC;

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -153,7 +153,7 @@ static bool isEventCallbackInvoked = false;
 /* Called before each test method. */
 void setUp()
 {
-    memset( ( void * ) mqttBuffer, 0x0, sizeof( mqttBuffer ) );
+    memset( mqttBuffer, 0x0, sizeof( mqttBuffer ) );
     MQTT_State_strerror_IgnoreAndReturn( "DUMMY_MQTT_STATE" );
 
     globalEntryTime = 0;
@@ -619,7 +619,7 @@ void test_MQTT_Connect_sendConnect( void )
     setupTransportInterface( &transport );
     setupNetworkBuffer( &networkBuffer );
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
 
     /* Check parameters */
@@ -632,7 +632,7 @@ void test_MQTT_Connect_sendConnect( void )
 
     /* Empty connect info fails. */
     MQTT_GetConnectPacketSize_ExpectAnyArgsAndReturn( MQTTBadParameter );
-    memset( ( void * ) &connectInfo, 0x0, sizeof( connectInfo ) );
+    memset( &connectInfo, 0x0, sizeof( connectInfo ) );
     status = MQTT_Connect( &mqttContext, &connectInfo, NULL, timeout, &sessionPresent );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 
@@ -693,7 +693,7 @@ void test_MQTT_Connect_receiveConnack( void )
     setupNetworkBuffer( &networkBuffer );
     transport.recv = transportRecvFailure;
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
 
     /* Everything before receiving the CONNACK should succeed. */
@@ -764,7 +764,7 @@ void test_MQTT_Connect_receiveConnack_retries( void )
     setupNetworkBuffer( &networkBuffer );
     transport.recv = transportRecvFailure;
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
 
     /* Everything before receiving the CONNACK should succeed. */
@@ -824,7 +824,7 @@ void test_MQTT_Connect_partial_receive()
     setupNetworkBuffer( &networkBuffer );
     transport.recv = transportRecvOneByte;
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
 
     /* Everything before receiving the CONNACK should succeed. */
@@ -898,8 +898,8 @@ void test_MQTT_Connect_resendPendingAcks( void )
     setupTransportInterface( &transport );
     setupNetworkBuffer( &networkBuffer );
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    memset( ( void * ) &connectInfo, 0x00, sizeof( connectInfo ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &connectInfo, 0x00, sizeof( connectInfo ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
 
     MQTT_SerializeConnect_IgnoreAndReturn( MQTTSuccess );
@@ -1030,7 +1030,7 @@ void test_MQTT_Connect_happy_path()
     setupTransportInterface( &transport );
     setupNetworkBuffer( &networkBuffer );
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
     connectInfo.keepAliveSeconds = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
 
@@ -1161,8 +1161,8 @@ void test_MQTT_Publish( void )
     setupNetworkBuffer( &networkBuffer );
     transport.send = transportSendFailure;
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
-    memset( ( void * ) &publishInfo, 0x0, sizeof( publishInfo ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &publishInfo, 0x0, sizeof( publishInfo ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
 
     /* Verify parameters. */
@@ -1177,7 +1177,7 @@ void test_MQTT_Publish( void )
     publishInfo.pPayload = NULL;
     status = MQTT_Publish( &mqttContext, &publishInfo, PACKET_ID );
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
-    memset( ( void * ) &publishInfo, 0x0, sizeof( publishInfo ) );
+    memset( &publishInfo, 0x0, sizeof( publishInfo ) );
 
     /* Bad Parameter when getting packet size. */
     publishInfo.qos = MQTTQoS0;
@@ -1301,7 +1301,7 @@ void test_MQTT_Disconnect( void )
     transport.recv = transportRecvSuccess;
     transport.send = transportSendFailure;
 
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
     mqttContext.connectStatus = MQTTConnected;
 
@@ -1343,7 +1343,7 @@ void test_MQTT_GetPacketId( void )
 
     setupTransportInterface( &transport );
     setupNetworkBuffer( &networkBuffer );
-    memset( ( void * ) &mqttContext, 0x0, sizeof( mqttContext ) );
+    memset( &mqttContext, 0x0, sizeof( mqttContext ) );
     MQTT_Init( &mqttContext, &transport, getTime, eventCallback, &networkBuffer );
 
     /* Verify parameters. */


### PR DESCRIPTION
*Description*:
Set payload to NULL for zero length payloads:
 * `MQTT_DeserializePublish` sets `pPayload` to point to the byte after the topic name (or packet ID for QoS > 0). If there is no payload, then this could point to garbage data in the buffer. `payloadLength` is correctly set to 0 for this case, but it also makes sense to set the payload to NULL as well.

Improve unit tests for MQTT_DeserializePublish:
 * The unit tests for `MQTT_DeserializePublish` don't reset its `publishInfo` struct between test cases. Before a test, its pointers point to constant strings, but are changed to point to the serialized buffer afterwards. This is an issue for the next test as it will try to serialize the data into the same buffer that is being pointed to, and mangles the data.
 * The deserialized publish information isn't checked, only the return code. The above test issue was caught when adding these checks.
 * Added unit test to check for a NULL pointer when payloads are zero length.
