### PR TITLE
Remove unused include directory from the CMakeLists.

### DIFF
--- a/mqttFilePaths.cmake
+++ b/mqttFilePaths.cmake
@@ -18,7 +18,3 @@ set( MQTT_SERIALIZER_SOURCES
 set( MQTT_INCLUDE_PUBLIC_DIRS
      "${CMAKE_CURRENT_LIST_DIR}/source/include"
      "${CMAKE_CURRENT_LIST_DIR}/source/portable" )
-
-# MQTT library Private Include directories.
-set( MQTT_INCLUDE_PRIVATE_DIRS
-     "${CMAKE_CURRENT_LIST_DIR}/source" )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,9 +45,6 @@ target_compile_definitions( coverity_analysis PUBLIC MQTT_DO_NOT_USE_CUSTOM_CONF
 # MQTT public include path.
 target_include_directories( coverity_analysis PUBLIC ${MQTT_INCLUDE_PUBLIC_DIRS} )
 
-# MQTT private include path.
-target_include_directories( coverity_analysis PRIVATE ${MQTT_INCLUDE_PRIVATE_DIRS} )
-
 #  ====================================  Test Configuration ========================================
 
 # Define a CMock resource path.

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -32,7 +32,6 @@ list(APPEND real_source_files
 list(APPEND real_include_directories
             .
             ${MQTT_INCLUDE_PUBLIC_DIRS}
-            ${MQTT_INCLUDE_PRIVATE_DIRS}
         )
 
 # =====================  Create UnitTest Code here (edit)  =====================
@@ -41,7 +40,6 @@ list(APPEND real_include_directories
 list(APPEND test_include_directories
             .
             ${MQTT_INCLUDE_PUBLIC_DIRS}
-            ${MQTT_INCLUDE_PRIVATE_DIRS}
         )
 
 # =============================  (end edit)  ===================================


### PR DESCRIPTION
Removed MQTT_INCLUDE_PRIVATE_DIRS from the CMake config files because there are no header files in there and files in that directory are not referenced in any #include in any library source, tests, or demos. 

Next PR (in CSDK):
- Update the submodule pointer in the CSDK repo and delete MQTT_INCLUDE_PRIVATE_DIRS everywhere.