### PR TITLE
Fix build warnings and unit test improvements

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -48,6 +48,8 @@ deserialize
 deserializeack
 deserialized
 deserializepublish
+deserializer
+deserializestatus
 deserializing
 didn
 disconnectpacketsize
@@ -199,6 +201,7 @@ pcurrentstate
 pcursor
 pdeserializedinfo
 pdestination
+pexpectparams
 pfilter
 pfilterindex
 pfixedbuffer
@@ -236,6 +239,7 @@ premainingdata
 premaininglength
 presendpublish
 processloop
+processloopstatus
 psessionpresent
 psource
 pstate
@@ -296,6 +300,7 @@ serializepayload
 serializepingreq
 serializepublish
 serializepublishheader
+serializestatus
 serializesubscribe
 serializeunsubscribe
 sessionpresent
@@ -308,6 +313,7 @@ somepassword
 someusername
 sourcelength
 stateafterdeserialize
+stateafterserialize
 statuscount
 strerror
 strlen


### PR DESCRIPTION
*Description*:
Several calls to `expectProcessLoopCalls` in `core_mqtt_utest.c` used the `MQTTStateNull` enum instead of `MQTTSuccess`, and resulted in compiler warnings from llvm:
```
 ◌ libraries/standard/coreMQTT/test/unit-test/core_mqtt_utest.c:
     1693:39  	clang       	warning   	Implicit conversion from enumeration type 'enum MQTTPublishState' to different enumeration type 'MQTTStatus_t' (aka 'enum MQTTStatus')
     1704:39  	clang       	warning   	Implicit conversion from enumeration type 'enum MQTTPublishState' to different enumeration type 'MQTTStatus_t' (aka 'enum MQTTStatus')
     1715:39  	clang       	warning   	Implicit conversion from enumeration type 'enum MQTTPublishState' to different enumeration type 'MQTTStatus_t' (aka 'enum MQTTStatus')
     1725:39  	clang       	warning   	Implicit conversion from enumeration type 'enum MQTTPublishState' to different enumeration type 'MQTTStatus_t' (aka 'enum MQTTStatus')
     1754:39  	clang       	warning   	Implicit conversion from enumeration type 'enum MQTTPublishState' to different enumeration type 'MQTTStatus_t' (aka 'enum MQTTStatus')
```

Since `expectProcessLoopCalls` has many parameters, it's not obvious from looking at it in each call what each parameter is doing, and whether it's actually necessary. This introduces a structure to hold `expectProcessLoopCalls`' parameters, and only the parameters that are actually used will have to be changed in each invocation.
