### PR TITLE
Update submodule configuration for hub repo cloning efficiency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
-      - run: git submodule update --checkout
+      - name: Checkout CMock submodule
+        run: git submodule update --init --checkout test/unit-test/CMock
       - name: Build
         run: |
           sudo apt-get install -y lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
-        run: git submodule update --checkout
+      - run: git submodule update --checkout
       - name: Build
         run: |
           sudo apt-get install -y lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v2
+        run: git submodule update --checkout
       - name: Build
         run: |
           sudo apt-get install -y lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Clone This Repo
         uses: actions/checkout@v2
       - name: Checkout CMock submodule
-        run: git submodule update --init --checkout test/unit-test/CMock
+        run: git submodule update --checkout --init --recursive test/unit-test/CMock
       - name: Build
         run: |
           sudo apt-get install -y lcov

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "test/unit-test/CMock"]
 	path = test/unit-test/CMock
 	url = https://github.com/ThrowTheSwitch/CMock
+	update = none
 [submodule "test/cbmc/aws-templates-for-cbmc-proofs"]
 	path = test/cbmc/aws-templates-for-cbmc-proofs
 	url = https://github.com/awslabs/aws-templates-for-cbmc-proofs.git
+	update = none
 [submodule "test/cbmc/litani"]
 	path = test/cbmc/litani
 	url = https://github.com/awslabs/aws-build-accumulator
+	update = none

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ By default, the submodules in this repository are configured with `update=none` 
 
 To build unit tests, the submodule dependency of CMock is required. Use the following command to clone the submodule:
 ```
-git submodule update --checkout --test/unit-test/CMock
+git submodule update --checkout --init --recursive --test/unit-test/CMock
 ```
 
 ### Platform Prerequisites

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git submodule update --checkout --init --recursive --test/unit-test/CMock
 
 ### Steps to build **Unit Tests**
 
-1. Go to the root directory of this repository. (Make sure that the **CMock** submodule is cloned as described [above]())
+1. Go to the root directory of this repository. (Make sure that the **CMock** submodule is cloned as described [above](#checkout-cmock-submodule))
 
 1. Run the *cmake* command: `cmake -S test -B build -DBUILD_CLONE_SUBMODULES=ON `
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ For a CMake example of building the MQTT library with the `mqttFilePaths.cmake` 
 
 ## Building Unit Tests
 
+### Checkout CMock Submodule
+By default, the submodules in this repository are configured with `update=none` in [.gitmodules](.gitmodules) to avoid increasing clone time and disk space usage of other repositories (like [amazon-freertos](https://github.com/aws/amazon-freertos) that submodule this repository.
+
+To build unit tests, the submodule dependency of CMock is required. Use the following command to clone the submodule:
+```
+git submodule update --checkout --test/unit-test/CMock
+```
+
 ### Platform Prerequisites
 
 - For running unit tests
@@ -39,7 +47,7 @@ For a CMake example of building the MQTT library with the `mqttFilePaths.cmake` 
 
 ### Steps to build **Unit Tests**
 
-1. Go to the root directory of this repository.
+1. Go to the root directory of this repository. (Make sure that the **CMock** submodule is cloned as described [above]())
 
 1. Run the *cmake* command: `cmake -S test -B build -DBUILD_CLONE_SUBMODULES=ON `
 


### PR DESCRIPTION
Reduce the cloning time of hub repositories (`aws/aws-iot-device-sdk-embedded-C`, `aws/amazon-freertos`) that consume this repository by updating submodules to not be auto-cloned for `git submodule update --init --recursive` command in the hub repositories
