### PR TITLE
Resend PUBACK and PUBREC irrespective of the DUP flag

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1069,7 +1069,7 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
 
             if( publishInfo.dup == false )
             {
-                LogError( ( "DUP flag is 0 for duplicate publish packet." ) );
+                LogError( ( "DUP flag is 0 for duplicate incoming publish packet." ) );
             }
         }
         else

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1069,7 +1069,7 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
 
             if( publishInfo.dup == false )
             {
-                LogError( ( "DUP flag is 0 for duplicate incoming publish packet." ) );
+                LogError( ( "DUP flag is 0 for duplicate packet (MQTT-3.3.1.-1)." ) );
             }
         }
         else

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1064,15 +1064,12 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
             publishRecordState = MQTT_CalculateStatePublish( MQTT_RECEIVE,
                                                              publishInfo.qos );
 
-            if( publishInfo.dup )
+            LogDebug( ( "Incoming publish packet with packet id %u already exists.",
+                        packetIdentifier ) );
+
+            if( publishInfo.dup == false )
             {
-                LogDebug( ( "Incoming publish packet with packet id %u already exists.",
-                            packetIdentifier ) );
-            }
-            else
-            {
-                LogError( ( "Incoming publish packet with packet id %u already exists, but DUP flag is 0.",
-                            packetIdentifier ) );
+                LogError( ( "DUP flag is 0 for duplicate publish packet." ) );
             }
         }
         else

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1054,7 +1054,7 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
          *       state engine. This will be handled by ignoring the
          *       #MQTTStateCollision status from the state engine. The publish
          *       data is not passed to the application. */
-        else if( ( status == MQTTStateCollision ) && ( publishInfo.dup == true ) )
+        else if( status == MQTTStateCollision )
         {
             status = MQTTSuccess;
             duplicatePublish = true;

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1063,8 +1063,17 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
              * for the duplicate incoming publish. */
             publishRecordState = MQTT_CalculateStatePublish( MQTT_RECEIVE,
                                                              publishInfo.qos );
-            LogDebug( ( "Incoming publish packet with packet id %u already exists.",
-                        packetIdentifier ) );
+
+            if( publishInfo.dup )
+            {
+                LogDebug( ( "Incoming publish packet with packet id %u already exists.",
+                            packetIdentifier ) );
+            }
+            else
+            {
+                LogError( ( "Incoming publish packet with packet id %u already exists, but DUP flag is 0.",
+                            packetIdentifier ) );
+            }
         }
         else
         {

--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -955,7 +955,7 @@ static MQTTStatus_t deserializeConnack( const MQTTPacketInfo_t * pConnack,
         if( ( pRemainingData[ 0 ] & MQTT_PACKET_CONNACK_SESSION_PRESENT_MASK )
             == MQTT_PACKET_CONNACK_SESSION_PRESENT_MASK )
         {
-            LogWarn( ( "CONNACK session present bit set." ) );
+            LogInfo( ( "CONNACK session present bit set." ) );
             *pSessionPresent = true;
 
             /* MQTT 3.1.1 specifies that the fourth byte in CONNACK must be 0 if the


### PR DESCRIPTION
In the OASIS MQTT Version 3.1.1 OASIS Standard, the following is stated:

> After it has sent a PUBACK Packet the Receiver MUST treat any incoming PUBLISH packet that contains the same Packet Identifier as being a new publication, irrespective of the setting of its DUP flag.

Also, when AWS IoT Core resends a PUBLISH with the same packet ID as the first that wasn't PUBACK'd, the DUP flag will always be set to 0. Therefore, our library will return `MQTTStateCollision` and will NOT send a PUBACK in response.

For QoS 2, the OASIS spec does not seem to explicitly state anything about whether or not to resend a PUBREC in response to a resent PUBLISH with the DUP flag set to 0. However, I think the same logic still applies, so the PUBREC must still be resent in that case. Feel free to disagree.
