### PR TITLE
Add a header files list for MQTT

### DIFF
--- a/mqttFilePaths.cmake
+++ b/mqttFilePaths.cmake
@@ -24,4 +24,5 @@ set( MQTT_HEADER_FILES
      "${CMAKE_CURRENT_LIST_DIR}/source/include/core_mqtt.h"
      "${CMAKE_CURRENT_LIST_DIR}/source/include/core_mqtt_serializer.h"
      "${CMAKE_CURRENT_LIST_DIR}/source/include/core_mqtt_state.h"
+     "${CMAKE_CURRENT_LIST_DIR}/source/include/core_mqtt_config_defaults.h"
      "${CMAKE_CURRENT_LIST_DIR}/source/portable/transport_interface.h" )

--- a/mqttFilePaths.cmake
+++ b/mqttFilePaths.cmake
@@ -18,3 +18,10 @@ set( MQTT_SERIALIZER_SOURCES
 set( MQTT_INCLUDE_PUBLIC_DIRS
      "${CMAKE_CURRENT_LIST_DIR}/source/include"
      "${CMAKE_CURRENT_LIST_DIR}/source/portable" )
+
+# MQTT library header files.
+set( MQTT_HEADER_FILES
+     "${CMAKE_CURRENT_LIST_DIR}/source/include/core_mqtt.h"
+     "${CMAKE_CURRENT_LIST_DIR}/source/include/core_mqtt_serializer.h"
+     "${CMAKE_CURRENT_LIST_DIR}/source/include/core_mqtt_state.h"
+     "${CMAKE_CURRENT_LIST_DIR}/source/portable/transport_interface.h" )


### PR DESCRIPTION
Update the `mqttFilePaths.cmake` script to include a list for the header files. 

The header files are required in the `amazon-freertos` CMake configuration of the MQTT library so that the generated metadata (with the `-DAFR_METADATA_MODE=1` flag) includes the list of header files