### PR TITLE
Remove const qualifier from send/recv in transport interface

### DIFF
--- a/docs/doxygen/porting.dox
+++ b/docs/doxygen/porting.dox
@@ -36,13 +36,13 @@ A port must implement functions corresponding to the following functions pointer
  - [Transport Receive](@ref TransportRecv_t): A function to receive bytes from a network.
  @code
  int32_t (* TransportRecv_t )(
-     const NetworkContext_t * pNetworkContext, void * pBuffer, size_t bytesToRecv
+     NetworkContext_t * pNetworkContext, void * pBuffer, size_t bytesToRecv
  );
  @endcode
  - [Transport Send](@ref TransportSend_t): A function to send bytes over a network.
  @code
  int32_t (* TransportSend_t )(
-     const NetworkContext_t * pNetworkContext, const void * pBuffer, size_t bytesToSend
+     NetworkContext_t * pNetworkContext, const void * pBuffer, size_t bytesToSend
  );
  @endcode
 

--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -295,7 +295,7 @@ static uint8_t * encodeString( uint8_t * pDestination,
  * @return The Remaining Length of the incoming packet.
  */
 static size_t getRemainingLength( TransportRecv_t recvFunc,
-                                  const NetworkContext_t * pNetworkContext );
+                                  NetworkContext_t * pNetworkContext );
 
 /**
  * @brief Check if an incoming packet type is valid.
@@ -706,7 +706,7 @@ static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
 }
 
 static size_t getRemainingLength( TransportRecv_t recvFunc,
-                                  const NetworkContext_t * pNetworkContext )
+                                  NetworkContext_t * pNetworkContext )
 {
     size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
     uint8_t encodedByte = 0;
@@ -2339,7 +2339,7 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
 /*-----------------------------------------------------------*/
 
 MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( TransportRecv_t readFunc,
-                                                  const NetworkContext_t * pNetworkContext,
+                                                  NetworkContext_t * pNetworkContext,
                                                   MQTTPacketInfo_t * pIncomingPacket )
 {
     MQTTStatus_t status = MQTTSuccess;

--- a/source/include/core_mqtt_serializer.h
+++ b/source/include/core_mqtt_serializer.h
@@ -1181,7 +1181,7 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
  */
 /* @[declare_mqtt_getincomingpackettypeandlength] */
 MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( TransportRecv_t readFunc,
-                                                  const NetworkContext_t * pNetworkContext,
+                                                  NetworkContext_t * pNetworkContext,
                                                   MQTTPacketInfo_t * pIncomingPacket );
 /* @[declare_mqtt_getincomingpackettypeandlength] */
 

--- a/source/portable/transport_interface.h
+++ b/source/portable/transport_interface.h
@@ -91,7 +91,7 @@
  * <br><br>
  * <b>Example code:</b>
  * @code{c}
- * int32_t myNetworkRecvImplementation( const NetworkContext_t * pNetworkContext,
+ * int32_t myNetworkRecvImplementation( NetworkContext_t * pNetworkContext,
  *                                      void * pBuffer,
  *                                      size_t bytesToRecv )
  * {
@@ -123,7 +123,7 @@
  * <br><br>
  * <b>Example code:</b>
  * @code{c}
- * int32_t myNetworkSendImplementation( const NetworkContext_t * pNetworkContext,
+ * int32_t myNetworkSendImplementation( NetworkContext_t * pNetworkContext,
  *                                      const void * pBuffer,
  *                                      size_t bytesToSend )
  * {
@@ -166,7 +166,7 @@ typedef struct NetworkContext NetworkContext_t;
  * @return The number of bytes received or a negative error code.
  */
 /* @[define_transportrecv] */
-typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportRecv_t )( NetworkContext_t * pNetworkContext,
                                        void * pBuffer,
                                        size_t bytesToRecv );
 /* @[define_transportrecv] */
@@ -182,7 +182,7 @@ typedef int32_t ( * TransportRecv_t )( const NetworkContext_t * pNetworkContext,
  * @return The number of bytes sent or a negative error code.
  */
 /* @[define_transportsend] */
-typedef int32_t ( * TransportSend_t )( const NetworkContext_t * pNetworkContext,
+typedef int32_t ( * TransportSend_t )( NetworkContext_t * pNetworkContext,
                                        const void * pBuffer,
                                        size_t bytesToSend );
 /* @[define_transportsend] */

--- a/test/unit-test/core_mqtt_serializer_utest.c
+++ b/test/unit-test/core_mqtt_serializer_utest.c
@@ -177,7 +177,7 @@ int suiteTearDown( int numFailures )
 /**
  * @brief Mock successful transport receive by reading data from a buffer.
  */
-static int32_t mockReceive( const NetworkContext_t * pNetworkContext,
+static int32_t mockReceive( NetworkContext_t * pNetworkContext,
                             void * pBuffer,
                             size_t bytesToRecv )
 {
@@ -203,7 +203,7 @@ static int32_t mockReceive( const NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive with no data available.
  */
-static int32_t mockReceiveNoData( const NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveNoData( NetworkContext_t * pNetworkContext,
                                   void * pBuffer,
                                   size_t bytesToRecv )
 {
@@ -218,7 +218,7 @@ static int32_t mockReceiveNoData( const NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive failure.
  */
-static int32_t mockReceiveFailure( const NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveFailure( NetworkContext_t * pNetworkContext,
                                    void * pBuffer,
                                    size_t bytesToRecv )
 {
@@ -233,7 +233,7 @@ static int32_t mockReceiveFailure( const NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive that succeeds once, then fails.
  */
-static int32_t mockReceiveSucceedThenFail( const NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveSucceedThenFail( NetworkContext_t * pNetworkContext,
                                            void * pBuffer,
                                            size_t bytesToRecv )
 {

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -197,7 +197,7 @@ int suiteTearDown( int numFailures )
  * @brief Mock successful transport send, and write data into buffer for
  * verification.
  */
-static int32_t mockSend( const NetworkContext_t * pNetworkContext,
+static int32_t mockSend( NetworkContext_t * pNetworkContext,
                          const void * pMessage,
                          size_t bytesToSend )
 {
@@ -277,7 +277,7 @@ static uint32_t getTimeDummy( void )
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportSendSuccess( const NetworkContext_t * pNetworkContext,
+static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -289,7 +289,7 @@ static int32_t transportSendSuccess( const NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked failed transport send.
  */
-static int32_t transportSendFailure( const NetworkContext_t * pNetworkContext,
+static int32_t transportSendFailure( NetworkContext_t * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -302,7 +302,7 @@ static int32_t transportSendFailure( const NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport send that succeeds then fails.
  */
-static int32_t transportSendSucceedThenFail( const NetworkContext_t * pNetworkContext,
+static int32_t transportSendSucceedThenFail( NetworkContext_t * pNetworkContext,
                                              const void * pMessage,
                                              size_t bytesToSend )
 {
@@ -330,7 +330,7 @@ static int32_t transportSendSucceedThenFail( const NetworkContext_t * pNetworkCo
  *
  * @return Number of bytes received; negative value on error.
  */
-static int32_t transportRecvSuccess( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -342,7 +342,7 @@ static int32_t transportRecvSuccess( const NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked failed transport read.
  */
-static int32_t transportRecvFailure( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecvFailure( NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -355,7 +355,7 @@ static int32_t transportRecvFailure( const NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport reading one byte at a time.
  */
-static int32_t transportRecvOneByte( const NetworkContext_t * pNetworkContext,
+static int32_t transportRecvOneByte( NetworkContext_t * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {


### PR DESCRIPTION
This follows changes from [https://github.com/FreeRTOS/FreeRTOS/commit/398abbaa6199a12377a6254b197ab12f9788cc32](https://github.com/FreeRTOS/FreeRTOS/commit/398abbaa6199a12377a6254b197ab12f9788cc32). The const qualifier is removed from send/recv because there are transport implementations that require a member of the network context to be modified such as in the case of mbedtls.