### PR TITLE
Display file-specific branch coverage in CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*test*' --output-file build/coverage.info
           lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*CMakeCCompilerId*' --output-file build/coverage.info
           lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*mocks*' --output-file build/coverage.info
-          lcov --list build/coverage.info
+          lcov --rc lcov_branch_coverage=1 --list build/coverage.info
       - name: Check Coverage
         uses: ChicagoFlutter/lcov-cop@v1.0.2
         with:


### PR DESCRIPTION
Update GitHub Actions step **Run Coverage** to show file-specific branch coverage in the summary results

Before: https://github.com/FreeRTOS/coreMQTT/runs/1299358013#step:6:232
![image](https://user-images.githubusercontent.com/5158611/97364000-9f17db80-1860-11eb-959c-254c5c5180d1.png)

After: https://github.com/aggarw13/coreMQTT/runs/1317388790#step:6:229
![image](https://user-images.githubusercontent.com/5158611/97364084-bb1b7d00-1860-11eb-855a-0ec472dada07.png)

