### PR TITLE
Print only a single set of results from lcov coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
-          EXCLUDE: ["\*test\*", "\*CMakeCCompilerId\*", "\*mocks\*"]
         run: |
           make -C build/ coverage
+          declare -a EXCLUDE=("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
           make -C build/ coverage
           for i in "${EXCLUDE[@]}"
           do
-            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info $i --output-file build/coverage.info
+            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '$i' --output-file build/coverage.info
           done
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
-          CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
+          CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CODE_COVERAGE}%"
           if (( $(echo "$CODE_COVERAGE < $2" | bc) )); then exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,15 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
-          EXCLUDE: ('"*test*"' '"*CMakeCCompilerId*"' '"*mocks*"' '"**/*test*"')
+          EXCLUDE: ("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*" "**/*test*")
         run: |
           make -C build/ coverage
-          echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
+          echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CUR_COVERAGE}%"
-          if (( $(echo "$CODE_COVERAGE < $MIN_COVERAGE" | bc) )); then exit 1; fi
+          if (( $(echo "$CUR_COVERAGE < $MIN_COVERAGE" | bc) )); then exit 1; fi
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          sudo apt-get install -y lcov
+          sudo apt-get install -y lcov xargs
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
@@ -33,12 +33,12 @@ jobs:
           EXCLUDE: ('"*test*"' '"*CMakeCCompilerId*"' '"*mocks*"' '"**/*test*"')
         run: |
           make -C build/ coverage
-          echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
+          echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CUR_COVERAGE}%"
-          if [ $MIN_COVERAGE -gt $CUR_COVERAGE ]; then exit 1; fi
+          if (( $(echo "$CODE_COVERAGE < $MIN_COVERAGE" | bc) )); then exit 1; fi
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,9 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
-          EXCLUDE: ("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
+          EXCLUDE: ["\*test\*", "\*CMakeCCompilerId\*", "\*mocks\*"]
         run: |
           make -C build/ coverage
-          for i in "${EXCLUDE[@]}"
-          do
-            echo $i
-          done
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           MIN_COVERAGE: 100
         run: |
           make -C build/ coverage
-          declare -a EXCLUDE=("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
+          declare -a EXCLUDE=("\*test\*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
           for i in "${EXCLUDE[@]}"
           do
             echo $i

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
           ctest -E system --output-on-failure
           cd ..
       - name: Run Coverage
-        env:
-          MIN_COVERAGE: 100
         run: |
           make -C build/ coverage
           declare -a EXCLUDE=("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,21 @@ jobs:
           cd build/
           ctest -E system --output-on-failure
           cd ..
-      - name: Run Coverage
+      - name: Check Coverage
+        env:
+          MIN_COVERAGE: 100
+          EXCLUDE: ("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
         run: |
           make -C build/ coverage
-          declare -a filters=("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
-          for i in "${filters[@]}"
+          for i in "${EXCLUDE[@]}"
           do
-            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '$i' --output-file build/coverage.info
+            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info $i --output-file build/coverage.info
           done
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
-      - name: Check Coverage
-        uses: ChicagoFlutter/lcov-cop@v1.0.2
-        with:
-          path: "build/coverage.info"
-          min_coverage: 100
+          CODE_COVERAGE=$(lcov --list ${LCOV_PATH} | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
+          echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
+          echo "Current Code Coverage: ${CODE_COVERAGE}%"
+          if (( $(echo "$CODE_COVERAGE < $2" | bc) )); then exit 1; fi
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           cd build/
           ctest -E system --output-on-failure
           cd ..
-      - name: Check Coverage
+      - name: Run Coverage
         env:
           MIN_COVERAGE: 100
         run: |
@@ -35,10 +35,12 @@ jobs:
           declare -a EXCLUDE=("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
-          CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
-          echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
-          echo "Current Code Coverage: ${CUR_COVERAGE}%"
-          if (( $(echo "$CUR_COVERAGE < $MIN_COVERAGE" | bc) )); then exit 1; fi
+      - name: Check Coverage
+        uses: ChicagoFlutter/lcov-cop@v1.0.2
+        with:
+          path: "build/coverage.info"
+          min_coverage: 100
+          exclude: "**/*test*"
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,10 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
+          EXCLUDE: ("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
         run: |
           make -C build/ coverage
-          declare -a EXCLUDE=("\*test\*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
-          for i in "${EXCLUDE[@]}"
-          do
-            echo $i
-          done
+          declare -a 
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,14 @@ jobs:
         env:
           MIN_COVERAGE: 100
           EXCLUDE: ("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
+          LCOV_PATH: build/coverage.info
         run: |
           make -C build/ coverage
           for i in "${EXCLUDE[@]}"
           do
-            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info $i --output-file build/coverage.info
+            lcov --rc lcov_branch_coverage=1 --remove ${LCOV_PATH} $i --output-file ${LCOV_PATH}
           done
-          lcov --rc lcov_branch_coverage=1 --list build/coverage.info
+          lcov --rc lcov_branch_coverage=1 --list ${LCOV_PATH}
           CODE_COVERAGE=$(lcov --list ${LCOV_PATH} | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CODE_COVERAGE}%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
-          EXCLUDE: ("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*" "**/*test*")
         run: |
           make -C build/ coverage
+          EXCLUDE=("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
           echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
-          EXCLUDE: ("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
+          EXCLUDE: ('"*test*"' '"*CMakeCCompilerId*"' '"*mocks*"' '"**/*test*"')
         run: |
           make -C build/ coverage
           echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
@@ -38,7 +38,7 @@ jobs:
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CUR_COVERAGE}%"
-          if [ "$MIN_COVERAGE" -gt "$CUR_COVERAGE" ]; then exit 1; fi
+          if [ $MIN_COVERAGE -gt $CUR_COVERAGE ]; then exit 1; fi
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,14 @@ jobs:
         env:
           MIN_COVERAGE: 100
           EXCLUDE: ("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
-          LCOV_PATH: build/coverage.info
         run: |
           make -C build/ coverage
           for i in "${EXCLUDE[@]}"
           do
-            lcov --rc lcov_branch_coverage=1 --remove ${LCOV_PATH} $i --output-file ${LCOV_PATH}
+            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info $i --output-file build/coverage.info
           done
-          lcov --rc lcov_branch_coverage=1 --list ${LCOV_PATH}
-          CODE_COVERAGE=$(lcov --list ${LCOV_PATH} | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
+          lcov --rc lcov_branch_coverage=1 --list build/coverage.info
+          CODE_COVERAGE=$(lcov --list build/coverage.info | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CODE_COVERAGE}%"
           if (( $(echo "$CODE_COVERAGE < $2" | bc) )); then exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,7 @@ jobs:
           EXCLUDE: ("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
         run: |
           make -C build/ coverage
-          for i in "${EXCLUDE[@]}"
-          do
-            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info ${i} --output-file build/coverage.info
-          done
+          echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info '$i' -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           EXCLUDE: ("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
         run: |
           make -C build/ coverage
-          echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info '$i' -o build/coverage.info
+          echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
           make -C build/ coverage
           for i in "${EXCLUDE[@]}"
           do
-            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '$i' --output-file build/coverage.info
+            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info ${i} --output-file build/coverage.info
           done
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CODE_COVERAGE}%"
-          if (( $(echo "$CODE_COVERAGE < $2" | bc) )); then exit 1; fi
+          if (( $(echo "$CODE_COVERAGE < $MIN_COVERAGE" | bc) )); then exit 1; fi
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,17 @@ jobs:
       - name: Run Coverage
         run: |
           make -C build/ coverage
-          lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*test*' --output-file build/coverage.info
-          lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*CMakeCCompilerId*' --output-file build/coverage.info
-          lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '*mocks*' --output-file build/coverage.info
+          declare -a filters=("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
+          for i in "${filters[@]}"
+          do
+            lcov --rc lcov_branch_coverage=1 --remove build/coverage.info '$i' --output-file build/coverage.info
+          done
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
       - name: Check Coverage
         uses: ChicagoFlutter/lcov-cop@v1.0.2
         with:
           path: "build/coverage.info"
           min_coverage: 100
-          exclude: "**/*test*"
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           EXCLUDE: ("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
         run: |
           make -C build/ coverage
-          echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info '$i' -o build/coverage.info
+          echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info '$i' -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,9 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
-          EXCLUDE: ("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
+          EXCLUDE: ("\*test\*" "*CMakeCCompilerId*" "*mocks*")
         run: |
           make -C build/ coverage
-          declare -a 
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             lcov --rc lcov_branch_coverage=1 --remove build/coverage.info $i --output-file build/coverage.info
           done
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
-          CODE_COVERAGE=$(lcov --list build/coverage.info | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
+          CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
           echo "Current Code Coverage: ${CODE_COVERAGE}%"
           if (( $(echo "$CODE_COVERAGE < $2" | bc) )); then exit 1; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         run: |
-          sudo apt-get install -y lcov xargs
+          sudo apt-get install -y lcov
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,13 @@ jobs:
       - name: Check Coverage
         env:
           MIN_COVERAGE: 100
-          EXCLUDE: ("\*test\*" "*CMakeCCompilerId*" "*mocks*")
+          EXCLUDE: ("\*test\*" "\*CMakeCCompilerId\*" "\*mocks\*")
         run: |
           make -C build/ coverage
+          for i in "${EXCLUDE[@]}"
+          do
+            echo $i
+          done
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
           make -C build/ coverage
           echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
-          CODE_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
+          CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"
-          echo "Current Code Coverage: ${CODE_COVERAGE}%"
-          if (( $(echo "$CODE_COVERAGE < $MIN_COVERAGE" | bc) )); then exit 1; fi
+          echo "Current Code Coverage: ${CUR_COVERAGE}%"
+          if [ "$MIN_COVERAGE" -gt "$CUR_COVERAGE" ]; then exit 1; fi
   complexity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,12 @@ jobs:
           MIN_COVERAGE: 100
         run: |
           make -C build/ coverage
-          EXCLUDE=("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
-          echo $EXCLUDE | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
+          declare -a EXCLUDE=("*test*" "*CMakeCCompilerId*" "*mocks*" "**/*test*")
+          for i in "${EXCLUDE[@]}"
+          do
+            echo $i
+          done
+          echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
           CUR_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | sed -n "s/.*Total:|.*|\([^%]*\)%.*/\1/p")
           echo "Minumum Coverage Required: ${MIN_COVERAGE}%"


### PR DESCRIPTION
The original GA had to run `lcov` multiple times to remove sources from the report even though it could have just been run a single time. This also makes it so that the results are only printed once.