### PR TITLE
Remove the memcpy function body in MQTT_Connect and MQTT_SerializeConnect proofs.

### DIFF
--- a/test/cbmc/proofs/MQTT_Connect/Makefile
+++ b/test/cbmc/proofs/MQTT_Connect/Makefile
@@ -47,6 +47,12 @@ REMOVE_FUNCTION_BODY += MQTT_ProcessLoop
 REMOVE_FUNCTION_BODY += MQTT_ReceiveLoop
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_mqtt_c_handleIncomingPublish
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_mqtt_c_handleKeepAlive
+# This function body is removed to be replaced with the defined stub so that the
+# proof runs faster. The memcpy stub simply checks that the destination is
+# writable and that the source is writable, for the copy length specified. This
+# is safe to do becayse the results of the copy are not used later in the
+# function.
+REMOVE_FUNCTION_BODY += memcpy
 
 # The loops below are unwound once more than the timeout. The loops below use
 # the user passed in timeout to break the loop.

--- a/test/cbmc/proofs/MQTT_Connect/Makefile
+++ b/test/cbmc/proofs/MQTT_Connect/Makefile
@@ -49,8 +49,8 @@ REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_mqtt_c_handleIncomingPublish
 REMOVE_FUNCTION_BODY += __CPROVER_file_local_core_mqtt_c_handleKeepAlive
 # This function body is removed to be replaced with the defined stub so that the
 # proof runs faster. The memcpy stub simply checks that the destination is
-# writable and that the source is writable, for the copy length specified. This
-# is safe to do becayse the results of the copy are not used later in the
+# writable and that the source is readable, for the copy length specified. This
+# is safe to do because the results of the copy are not used later in the
 # function.
 REMOVE_FUNCTION_BODY += memcpy
 

--- a/test/cbmc/proofs/MQTT_SerializeConnect/Makefile
+++ b/test/cbmc/proofs/MQTT_SerializeConnect/Makefile
@@ -32,8 +32,8 @@ INCLUDES +=
 REMOVE_FUNCTION_BODY += MQTT_GetIncomingPacketTypeAndLength
 # This function body is removed to be replaced with the defined stub so that the
 # proof runs faster. The memcpy stub simply checks that the destination is
-# writable and that the source is writable, for the copy length specified. This
-# is safe to do becayse the results of the copy are not used later in the
+# writable and that the source is readable, for the copy length specified. This
+# is safe to do because the results of the copy are not used later in the
 # function.
 REMOVE_FUNCTION_BODY += memcpy
 

--- a/test/cbmc/proofs/MQTT_SerializeConnect/Makefile
+++ b/test/cbmc/proofs/MQTT_SerializeConnect/Makefile
@@ -26,10 +26,16 @@ PROOF_UID=MQTT_SerializeConnect
 DEFINES +=
 INCLUDES +=
 
-# This function does not coincide with the call graph of MQTT_Serialize, but are
+# This function does not coincide with the call graph of MQTT_Serialize, but is
 # found by CBMC during processing in logs/MQTT_Connect_harness3.txt. We remove
 # the function body to improve coverage accuracy.
 REMOVE_FUNCTION_BODY += MQTT_GetIncomingPacketTypeAndLength
+# This function body is removed to be replaced with the defined stub so that the
+# proof runs faster. The memcpy stub simply checks that the destination is
+# writable and that the source is writable, for the copy length specified. This
+# is safe to do becayse the results of the copy are not used later in the
+# function.
+REMOVE_FUNCTION_BODY += memcpy
 
 # The encodeRemainingLength loop is unwound 5 times because encodeRemainingLength()
 # divides a size_t variable by 128 until it reaches zero to stop the loop.


### PR DESCRIPTION
When developing the proofs I had added the memcpy stub to the list of files to compile. At the time, I noticed this didn't really help the run time. I just now realized that I had forgotten to remove the memcpy function body so that the proof can actually use the stub!