### PR TITLE
Add README.md link to memory estimates doxygen page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains the coreMQTT library that has been optimized for a low 
 
 This library has gone through code quality checks including verification that no function has a [GNU Complexity](https://www.gnu.org/software/complexity/manual/complexity.html) score over 8, and checks against deviations from mandatory rules in the [MISRA coding standard](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx).  Deviations from the MISRA C:2012 guidelines are documented under [MISRA Deviations](MISRA.md). This library has also undergone both static code analysis from [Coverity static analysis](https://scan.coverity.com/), and validation of memory safety and proof of functional correctness through the [CBMC automated reasoning tool](https://www.cprover.org/cbmc/).
 
+See memory requirements for this library [here](https://docs.aws.amazon.com/embedded-csdk/202011.00/lib-ref/libraries/standard/coreMQTT/docs/doxygen/output/html/index.html#mqtt_memory_requirements).
+
 ## MQTT Config File
 
 The MQTT client library exposes build configuration macros that are required for building the library.


### PR DESCRIPTION
Adding link in README to point to the library-specific doxygen page for memory estimates. Draft until doxygen links are live.