### PR TITLE
Add CRLF check to formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,13 @@ jobs:
           else
             exit 0
           fi
+      - name: Check for CRLF
+        run: |
+          set +e
+          find . -path ./.git -prune -o -exec file {} + |  grep "CRLF"
+          if [ "$?" = "0" ]; then
+            echo "Files have CRLF line endings."
+            exit 1
+          else
+            exit 0
+          fi


### PR DESCRIPTION
Have CI check for CRLF line endings to make sure line endings remain consistent. 