### PR TITLE
Fix incorrect size compiler warning

### DIFF
--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -65,7 +65,7 @@
 /**
  * @brief A PINGREQ packet is always 2 bytes in size, defined by MQTT 3.1.1 spec.
  */
-#define MQTT_PACKET_PINGREQ_SIZE                    ( 2U )
+#define MQTT_PACKET_PINGREQ_SIZE                    ( 2UL )
 
 /**
  * @brief The Remaining Length field of MQTT disconnect packets, per MQTT spec.


### PR DESCRIPTION
*Description*:
Compiling `core_mqtt_serializer.c` gives the following warning:
```
/Users/ahmemune/Documents/EmbeddedCSDK/libraries/standard/coreMQTT/source/core_mqtt_serializer.c:2218:25: warning: format specifies type 'unsigned long' but the argument has type 'unsigned int' [-Wformat]
                        MQTT_PACKET_PINGREQ_SIZE ) );
                        ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/ahmemune/Documents/EmbeddedCSDK/libraries/standard/coreMQTT/source/core_mqtt_serializer.c:68:53: note: expanded from macro 'MQTT_PACKET_PINGREQ_SIZE'
#define MQTT_PACKET_PINGREQ_SIZE                    ( 2U )
```
I updated the definition to an unsigned long, matching `MQTT_DISCONNECT_PACKET_SIZE`
