### PR TITLE
Remove %.*s format specifier from logs

### DIFF
--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -1263,10 +1263,7 @@ static MQTTStatus_t deserializePublish( const MQTTPacketInfo_t * pIncomingPacket
     {
         /* Parse the topic. */
         pPublishInfo->pTopicName = ( const char * ) ( pVariableHeader + sizeof( uint16_t ) );
-        LogDebug( ( "Topic name length %hu: %.*s",
-                    ( unsigned short ) pPublishInfo->topicNameLength,
-                    pPublishInfo->topicNameLength,
-                    pPublishInfo->pTopicName ) );
+        LogDebug( ( "Topic name length: %hu.", ( unsigned short ) pPublishInfo->topicNameLength ) );
 
         /* Extract the packet identifier for QoS 1 or 2 PUBLISH packets. Packet
          * identifier starts immediately after the topic name. */


### PR DESCRIPTION
*Description*:
Removes the only instance of a variable precision format specifier ("%.*s") used in logs (printing a topic name) due to concerns over portability. Since the buffer is not null terminated, it can't be printed otherwise, so the log was removed.
