### PR TITLE
Use stdbool.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
-  custom-header:
+  custom-standard-c-headers:
     runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
@@ -159,7 +159,6 @@ jobs:
           cp source/include/stdint.readme override-include/stdint.h
           cmake -S test -B build/ \
           -G "Unix Makefiles" \
-          -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='-Wall -Wextra -DNDEBUG -I../override-include'
+          -DCMAKE_C_FLAGS='-Wall -Wextra -I../override-include'
           make -C build/ coverity_analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,19 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
+  custom-header:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone This Repo
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          mkdir -p override-include
+          cp source/include/stdbool.readme override-include/stdbool.h
+          cp source/include/stdint.readme override-include/stdint.h
+          cmake -S test -B build/ \
+          -G "Unix Makefiles" \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_CLONE_SUBMODULES=ON \
+          -DCMAKE_C_FLAGS='-Wall -Wextra -DNDEBUG -I../override-include'
+          make -C build/ coverity_analysis

--- a/MISRA.md
+++ b/MISRA.md
@@ -15,8 +15,6 @@ Deviations from the MISRA standard are listed below:
 | Rule 2.5 | Advisory | Allow unused macros. Library headers may define macros intended for the application's use, but are not used by a specific file. |
 | Rule 3.1 | Required | Allow nested comments. C++ style `//` comments are used in example code within Doxygen documentation blocks. |
 | Rule 11.5 | Advisory | Allow casts from `void *`. Fields such as publish payloads are passed as `void *` and must be cast to the correct data type before use. |
-| Rule 21.1 | Required | Allow use of all macro names. For compatibility, some macros introduced in C99 are defined for use with C90 compilers. |
-| Rule 21.2 | Required | Allow use of all macro and identifier names. For compatibility, some macros introduced in C99 are defined for use with C90 compilers. |
 
 ### Flagged by Coverity
 | Deviation | Category | Justification |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ and build the library with default configuration values, provide `MQTT_DO_NOT_US
 
 The [mqttFilePaths.cmake](mqttFilePaths.cmake) file contains the information of all source files and the header include path required to build the MQTT library.
 
+Additionally, the MQTT library requires two header files that are not part of the ISO C90 standard library, `stdbool.h` and `stdint.h`. For compilers that do not provide these header files, the [source/include](source/include) directory contains the files [stdbool.readme](source/include/stdbool.readme) and [stdint.readme](source/include/stdint.readme), which can be renamed to `stdbool.h` and `stdint.h`, respectively, to provide the type definitions required by MQTT.
+
 As mentioned in the previous section, either a custom config file (i.e. `core_mqtt_config.h`) OR `MQTT_DO_NOT_USE_CUSTOM_CONFIG` macro needs to be provided to build the MQTT library.
 
 For a CMake example of building the MQTT library with the `mqttFilePaths.cmake` file, refer to the `coverity_analysis` library target in [test/CMakeLists.txt](test/CMakeLists.txt) file.

--- a/source/include/core_mqtt_serializer.h
+++ b/source/include/core_mqtt_serializer.h
@@ -32,21 +32,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-
-/**
- * @cond DOXYGEN_IGNORE
- * Doxygen should ignore this section.
- */
-
-/* bool is defined in only C99+. */
-#if defined( __cplusplus ) || ( defined( __STDC_VERSION__ ) && ( __STDC_VERSION__ >= 199901L ) )
-    #include <stdbool.h>
-#elif !defined( bool ) && !defined( false ) && !defined( true )
-    #define bool     int8_t
-    #define false    ( int8_t ) 0
-    #define true     ( int8_t ) 1
-#endif
-/** @endcond */
+#include <stdbool.h>
 
 /* MQTT_DO_NOT_USE_CUSTOM_CONFIG allows building the MQTT library
  * without a custom config. If a custom config is provided, the

--- a/source/include/stdbool.readme
+++ b/source/include/stdbool.readme
@@ -1,0 +1,31 @@
+
+#ifndef _STDBOOL_H
+#define _STDBOOL_H
+
+/*******************************************************************************
+ * This file contains the definitions specified in stdbool.h. It is provided to
+ * allow coreMQTT to be built using compilers that do not provide their own
+ * stdbool.h defintion.
+ *
+ * To use this file:
+ *
+ *    1) Copy this file into a directory that is in your compiler's include path.
+ *       The directory must be part of the include path for system header files,
+ *       for example passed using gcc's "-I" or "-isystem" options.
+ *
+ *    2) Rename the copied file stdbool.h.
+ *
+ */
+
+#ifndef __cplusplus
+
+/* _Bool was introduced in C99. */
+#define bool    int
+#define false   0
+#define true    1
+
+#endif
+
+#define __bool_true_false_are_defined   1
+
+#endif /* _STDBOOL_H */

--- a/source/include/stdbool.readme
+++ b/source/include/stdbool.readme
@@ -1,4 +1,3 @@
-
 #ifndef _STDBOOL_H
 #define _STDBOOL_H
 
@@ -20,12 +19,12 @@
 #ifndef __cplusplus
 
 /* _Bool was introduced in C99. */
-#define bool    42
-#define false   0
-#define true    1
+    #define bool     int
+    #define false    0
+    #define true     1
 
 #endif
 
-#define __bool_true_false_are_defined   1
+#define __bool_true_false_are_defined    1
 
 #endif /* _STDBOOL_H */

--- a/source/include/stdbool.readme
+++ b/source/include/stdbool.readme
@@ -20,7 +20,7 @@
 #ifndef __cplusplus
 
 /* _Bool was introduced in C99. */
-#define bool    int
+#define bool    42
 #define false   0
 #define true    1
 

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -1,4 +1,3 @@
-
 #ifndef _STDINT_H
 #define _STDINT_H
 
@@ -17,13 +16,13 @@
  *
  */
 
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef short int16_t;
-typedef unsigned short uint16_t;
-typedef long int32_t;
-typedef unsigned long uint32_t;
+typedef signed char      int8_t;
+typedef unsigned char    uint8_t;
+typedef short            int16_t;
+typedef unsigned short   uint16_t;
+typedef long             int32_t;
+typedef unsigned long    uint32_t;
 
-#define UINT16_MAX  ( ( unsigned short ) 65535 )
+#define UINT16_MAX    ( ( unsigned short ) 65535 )
 
 #endif /* _STDINT_H */

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -16,13 +16,22 @@
  *
  */
 
-typedef signed char      int8_t;
-typedef unsigned char    uint8_t;
-typedef short            int16_t;
-typedef unsigned short   uint16_t;
-typedef long             int32_t;
-typedef unsigned long    uint32_t;
+typedef signed char          int8_t;
+typedef unsigned char        uint8_t;
+typedef short                int16_t;
+typedef unsigned short       uint16_t;
+typedef long                 int32_t;
+typedef unsigned long        uint32_t;
+typedef long long            int64_t;
+typedef unsigned long long   uint64_t;
 
+#define INT8_MAX      ( ( signed char ) 127 )
+#define UINT8_MAX     ( ( unsigned char ) ) 255
+#define INT16_MAX     ( ( short ) 32767 )
 #define UINT16_MAX    ( ( unsigned short ) 65535 )
+#define INT32_MAX     2147483647L
+#define UINT32_MAX    4294967295UL
+#define INT64_MAX     9223372036854775807LL
+#define UINT64_MAX    18446744073709551615ULL
 
 #endif /* _STDINT_H */

--- a/source/include/stdint.readme
+++ b/source/include/stdint.readme
@@ -1,0 +1,29 @@
+
+#ifndef _STDINT_H
+#define _STDINT_H
+
+/*******************************************************************************
+ * THIS IS NOT A FULL stdint.h IMPLEMENTATION - It only contains the definitions
+ * necessary to build the coreMQTT code.  It is provided to allow coreMQTT to be
+ * built using compilers that do not provide their own stdint.h definition.
+ *
+ * To use this file:
+ *
+ *    1) Copy this file into a directory that is in your compiler's include path.
+ *       The directory must be part of the include path for system header file,
+ *       for example passed using gcc's "-I" or "-isystem" options.
+ *
+ *    2) Rename the copied file stdint.h.
+ *
+ */
+
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef short int16_t;
+typedef unsigned short uint16_t;
+typedef long int32_t;
+typedef unsigned long uint32_t;
+
+#define UINT16_MAX  ( ( unsigned short ) 65535 )
+
+#endif /* _STDINT_H */


### PR DESCRIPTION
*Description*:
Removes the preprocessor check that relies on C99 macros and just includes `stdbool.h`. A `stdbool.readme` file, along with `stdint.readme`, is provided for compilers that do not provide their respective headers
