### PR TITLE
Enable debug logging in unit-test build and fix logging compilation error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
-          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG'
+          -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
           make -C build/ all
       - name: Test
         run: |

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -107,6 +107,9 @@ keepalivems
 keepaliveseconds
 lastpackettime
 linux
+logdebug
+logerror
+loginfo
 logwarn
 lsb
 lwt
@@ -115,6 +118,7 @@ managekeepalive
 matchtopic
 memcpy
 memset
+metadata
 mib
 min
 misra

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -243,6 +243,7 @@ pre
 premainingdata
 premaininglength
 presendpublish
+printf
 processloop
 processloopstatus
 psessionpresent

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -743,8 +743,10 @@ static int32_t recvExact( const MQTTContext_t * pContext,
             totalBytesRecvd += ( int32_t ) bytesRecvd;
             pIndex += bytesRecvd;
             LogDebug( ( "BytesReceived=%ld, BytesRemaining=%lu, "
+                        "TotalBytesReceived=%ld.",
                         ( long int ) bytesRecvd,
-                        ( unsigned long ) bytesRemaining ) );
+                        ( unsigned long ) bytesRemaining,
+                        ( long int ) totalBytesRecvd ) );
         }
         else
         {

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -742,7 +742,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
             bytesRemaining -= ( size_t ) bytesRecvd;
             totalBytesRecvd += ( int32_t ) bytesRecvd;
             pIndex += bytesRecvd;
-            LogDebug( ( "BytesReceived=%ld, BytesRemaining=%lu, TotalBytesReceived=%ld.",
+            LogDebug( ( "BytesReceived=%ld, BytesRemaining=%lu, TotalBytesReceived=%ld."
                         ( long int ) bytesRecvd,
                         ( unsigned long ) bytesRemaining,
                         ( long int ) totalBytesRecvd ) );

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -742,8 +742,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
             bytesRemaining -= ( size_t ) bytesRecvd;
             totalBytesRecvd += ( int32_t ) bytesRecvd;
             pIndex += bytesRecvd;
-            LogDebug( ( "BytesReceived=%ld, BytesRemaining=%lu, "
-                        "TotalBytesReceived=%ld.",
+            LogDebug( ( "BytesReceived=%ld, BytesRemaining=%lu, TotalBytesReceived=%ld.",
                         ( long int ) bytesRecvd,
                         ( unsigned long ) bytesRemaining,
                         ( long int ) totalBytesRecvd ) );

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -742,7 +742,7 @@ static int32_t recvExact( const MQTTContext_t * pContext,
             bytesRemaining -= ( size_t ) bytesRecvd;
             totalBytesRecvd += ( int32_t ) bytesRecvd;
             pIndex += bytesRecvd;
-            LogDebug( ( "BytesReceived=%ld, BytesRemaining=%lu, TotalBytesReceived=%ld."
+            LogDebug( ( "BytesReceived=%ld, BytesRemaining=%lu, TotalBytesReceived=%ld.",
                         ( long int ) bytesRecvd,
                         ( unsigned long ) bytesRemaining,
                         ( long int ) totalBytesRecvd ) );

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND mock_list
 # list the directories your mocks need
 list(APPEND mock_include_list
             .
+            ${CMAKE_CURRENT_LIST_DIR}/logging
             ${MQTT_INCLUDE_PUBLIC_DIRS}
         )
 #list the definitions of your mocks to control what to be included
@@ -31,6 +32,7 @@ list(APPEND real_source_files
 # list the directories the module under test includes
 list(APPEND real_include_directories
             .
+            ${CMAKE_CURRENT_LIST_DIR}/logging
             ${MQTT_INCLUDE_PUBLIC_DIRS}
         )
 

--- a/test/unit-test/core_mqtt_config.h
+++ b/test/unit-test/core_mqtt_config.h
@@ -30,6 +30,32 @@
 /* Standard include. */
 #include <stdint.h>
 
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Include logging header files and define logging macros in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define the LIBRARY_LOG_NAME and LIBRARY_LOG_LEVEL macros depending on
+ * the logging configuration for MQTT.
+ * 3. Include the header file "logging_stack.h", if logging is enabled for MQTT.
+ */
+
+#include "logging_levels.h"
+
+/* Logging configuration for the MQTT library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME    "MQTT"
+#endif
+
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_DEBUG
+#endif
+
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
 /**
  * @brief Retry count for reading CONNACK from network.
  *

--- a/test/unit-test/core_mqtt_config.h
+++ b/test/unit-test/core_mqtt_config.h
@@ -49,7 +49,7 @@
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
-    #define LIBRARY_LOG_LEVEL    LOG_DEBUG
+    #define LIBRARY_LOG_LEVEL    LOG_NONE
 #endif
 
 #include "logging_stack.h"

--- a/test/unit-test/logging/logging_levels.h
+++ b/test/unit-test/logging/logging_levels.h
@@ -1,0 +1,105 @@
+/*
+ * coreMQTT v1.0.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file logging_levels.h
+ * @brief Defines the logging level macros.
+ */
+
+#ifndef LOGGING_LEVELS_H_
+#define LOGGING_LEVELS_H_
+
+/**
+ * @brief No log messages.
+ *
+ * When @ref LIBRARY_LOG_LEVEL is #LOG_NONE, logging is disabled and no
+ * logging messages are printed.
+ */
+#define LOG_NONE     0
+
+/**
+ * @brief Represents erroneous application state or event.
+ *
+ * These messages describe the situations when a library encounters an error from
+ * which it cannot recover.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #LOG_ERROR, #LOG_WARN, #LOG_INFO or #LOG_DEBUG.
+ */
+#define LOG_ERROR    1
+
+/**
+ * @brief Message about an abnormal event.
+ *
+ * These messages describe the situations when a library encounters
+ * abnormal event that may be indicative of an error. Libraries continue
+ * execution after logging a warning.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #LOG_WARN, #LOG_INFO or #LOG_DEBUG.
+ */
+#define LOG_WARN     2
+
+/**
+ * @brief A helpful, informational message.
+ *
+ * These messages describe normal execution of a library. They provide
+ * the progress of the program at a coarse-grained level.
+ *
+ * These messages are printed when @ref LIBRARY_LOG_LEVEL is defined as either
+ * of #LOG_INFO or #LOG_DEBUG.
+ */
+#define LOG_INFO     3
+
+/**
+ * @brief Detailed and excessive debug information.
+ *
+ * Debug log messages are used to provide the
+ * progress of the program at a fine-grained level. These are mostly used
+ * for debugging and may contain excessive information such as internal
+ * variables, buffers, or other specific information.
+ *
+ * These messages are only printed when @ref LIBRARY_LOG_LEVEL is defined as
+ * #LOG_DEBUG.
+ */
+#define LOG_DEBUG    4
+
+/* The macro definition for LIBRARY_LOG_LEVEL is for Doxygen
+ * documentation only. This macro is typically defined in only the
+ * <library>_config.h file or the demo_config.h file. */
+
+/**
+ * @brief The logging level verbosity configuration of log messages from library.
+ *
+ * The logging verbosity levels are one of #LOG_DEBUG, #LOG_INFO, #LOG_WARN,
+ * and #LOG_ERROR.
+ * - With level #LOG_NONE, logging will be disabled.
+ * - With level #LOG_DEBUG, all log messages will print.
+ * - With level #LOG_INFO, all log messages, except level #LOG_DEBUG, will print.
+ * - With level #LOG_WARN, only messages this level and #LOG_ERROR level will print.
+ * - With level #LOG_ERROR, only messages at this level will print.
+ */
+#ifdef DOXYGEN
+    #define LIBRARY_LOG_LEVEL    LOG_ERROR
+#endif
+
+#endif /* ifndef LOGGING_LEVELS_H_ */

--- a/test/unit-test/logging/logging_stack.h
+++ b/test/unit-test/logging/logging_stack.h
@@ -177,6 +177,6 @@
  */
     #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
 
-#endif /* ifdef DOXYGEN */
+#endif /* ifndef DOXYGEN */
 
 #endif /* ifndef LOGGING_STACK_H_ */

--- a/test/unit-test/logging/logging_stack.h
+++ b/test/unit-test/logging/logging_stack.h
@@ -1,0 +1,182 @@
+/*
+ * coreMQTT v1.0.1
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file logging_stack.h
+ * @brief Reference implementation of Logging stack as a header-only library.
+ */
+
+#ifndef LOGGING_STACK_H_
+#define LOGGING_STACK_H_
+
+/* Include header for logging level macros. */
+#include "logging_levels.h"
+
+/* Standard Include. */
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+/* The macro definition for LIBRARY_LOG_NAME is for Doxygen
+ * documentation only. This macro is typically defined in only the
+ * <library>_config.h file or the demo_config.h file. */
+
+/**
+ * @brief The name of the library or demo to add as metadata in log messages
+ * from the library or demo.
+ *
+ * This metadata aids in identifying the module source of log messages.
+ * The metadata is logged in the format `[ <LIBRARY-NAME> ]` as a prefix to the
+ * log messages.
+ * Refer to #LOG_METADATA_FORMAT for the complete format of the metadata prefix in
+ * log messages.
+ */
+#ifdef DOXYGEN
+    #define LIBRARY_LOG_NAME    "<LIBRARY_NAME>"
+#endif
+
+/* Check if LIBRARY_LOG_NAME macro has been defined. */
+#if !defined( LIBRARY_LOG_NAME )
+    #error "Please define LIBRARY_LOG_NAME for the library."
+#endif
+
+/**
+ * @brief Macro to extract only the file name from file path to use for metadata in
+ * log messages.
+ */
+#define FILENAME               ( strrchr( __FILE__, '/' ) ? strrchr( __FILE__, '/' ) + 1 : __FILE__ )
+
+/* Metadata information to prepend to every log message. */
+#define LOG_METADATA_FORMAT    "[%s] [%s:%d] "                      /**< @brief Format of metadata prefix in log messages as `[<Logging-Level>] [<Library-Name>] [<File-Name>:<Line-Number>]` */
+#define LOG_METADATA_ARGS      LIBRARY_LOG_NAME, FILENAME, __LINE__ /**< @brief Arguments into the metadata logging prefix format. */
+
+#if !defined( DISABLE_LOGGING )
+
+/**
+ * @brief Common macro that maps all the logging interfaces,
+ * (#LogDebug, #LogInfo, #LogWarn, #LogError) to the platform-specific logging
+ * function.
+ *
+ * `printf` from the standard C library is the POSIX platform implementation used
+ * for logging functionality.
+ */
+    #define SdkLog( string )    printf string
+#else
+    #define SdkLog( string )
+#endif
+
+/**
+ * Disable definition of logging interface macros when generating doxygen output,
+ * to avoid conflict with documentation of macros at the end of the file.
+ * @cond DOXYGEN_IGNORE
+ */
+/* Check that LIBRARY_LOG_LEVEL is defined and has a valid value. */
+#if !defined( LIBRARY_LOG_LEVEL ) ||       \
+    ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && \
+    ( LIBRARY_LOG_LEVEL != LOG_ERROR ) &&  \
+    ( LIBRARY_LOG_LEVEL != LOG_WARN ) &&   \
+    ( LIBRARY_LOG_LEVEL != LOG_INFO ) &&   \
+    ( LIBRARY_LOG_LEVEL != LOG_DEBUG )     \
+    )
+    #error "Please define LIBRARY_LOG_LEVEL as either LOG_NONE, LOG_ERROR, LOG_WARN, LOG_INFO, or LOG_DEBUG."
+#else
+    #if LIBRARY_LOG_LEVEL == LOG_DEBUG
+        /* All log level messages will logged. */
+        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )     SdkLog( ( "[INFO] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogDebug( message )    SdkLog( ( "[DEBUG] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+    #elif LIBRARY_LOG_LEVEL == LOG_INFO
+        /* Only INFO, WARNING and ERROR messages will be logged. */
+        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )     SdkLog( ( "[INFO] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogDebug( message )
+
+    #elif LIBRARY_LOG_LEVEL == LOG_WARN
+        /* Only WARNING and ERROR messages will be logged.*/
+        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogInfo( message )
+        #define LogDebug( message )
+
+    #elif LIBRARY_LOG_LEVEL == LOG_ERROR
+        /* Only ERROR messages will be logged. */
+        #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+        #define LogWarn( message )
+        #define LogInfo( message )
+        #define LogDebug( message )
+
+    #else /* if LIBRARY_LOG_LEVEL == LOG_ERROR */
+
+        #define LogError( message )
+        #define LogWarn( message )
+        #define LogInfo( message )
+        #define LogDebug( message )
+
+    #endif /* if LIBRARY_LOG_LEVEL == LOG_ERROR */
+#endif /* if !defined( LIBRARY_LOG_LEVEL ) || ( ( LIBRARY_LOG_LEVEL != LOG_NONE ) && ( LIBRARY_LOG_LEVEL != LOG_ERROR ) && ( LIBRARY_LOG_LEVEL != LOG_WARN ) && ( LIBRARY_LOG_LEVEL != LOG_INFO ) && ( LIBRARY_LOG_LEVEL != LOG_DEBUG ) ) */
+/** @endcond */
+
+/* Doxygen documentation of logging interface macro definitions for Doxygen. */
+#ifdef DOXYGEN
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Debug"
+ * level, when debug level logging is enabled.
+ *
+ * This macro is only enabled for #LOG_DEBUG level configuration in this
+ * logging stack implementation.
+ */
+    #define LogDebug( message )    SdkLog( ( "[DEBUG] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Info"
+ * level, when info level logging is enabled.
+ *
+ * This macro is only enabled for #LOG_DEBUG and #LOG_INFO level configurations
+ * in this logging stack implementation.
+ */
+    #define LogInfo( message )     SdkLog( ( "[INFO] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Warning"
+ * level, when warning level logging is enabled.
+ *
+ * This macro is only enabled for #LOG_DEBUG, #LOG_INFO and #LOG_WARN level
+ * configurations in this logging stack implementation.
+ */
+    #define LogWarn( message )     SdkLog( ( "[WARN] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+/**
+ * @brief Definition of logging interface macro that logs messages at the "Error"
+ * level, when error level logging is enabled.
+ *
+ * This macro is only enabled for all logging level configurations
+ * unless except the #LOG_NONE configuration.
+ */
+    #define LogError( message )    SdkLog( ( "[ERROR] "LOG_METADATA_FORMAT, LOG_METADATA_ARGS ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
+#endif /* ifdef DOXYGEN */
+
+#endif /* ifndef LOGGING_STACK_H_ */


### PR DESCRIPTION
- Update `core_mqtt_config.h` to specify logging level as `DEBUG`
- Fix `LogDebug` in `recvExact`