### PR TITLE
Fix issue in release workflow for tagging commit ID

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -31,7 +31,7 @@ jobs:
           git tag -d ${{ github.event.inputs.version_number }}
           git remote update
           git checkout tags/${{ github.event.inputs.version_number }}
-          git diff origin/${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
   create-zip:
     needs: tag-commit
     name: Create ZIP and verify package for release asset.


### PR DESCRIPTION
Fix issue in tag verification step of `release-workflow.yml` when release job is triggered with commit ID instead of branch name.

Here is a test run (on my fork) that uses commit ID: https://github.com/FreeRTOS/coreMQTT/actions/runs/406579636