### PR TITLE
Add doc that keep-alive is unsupported with dummy timer

### DIFF
--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -609,12 +609,12 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  * run, unless an error occurs.
  *
  * @note Calling this function blocks the calling context for a time period that
- * depends on the passed @p timeoutMs, the configuration macro, #MQTT_RECV_POLLING_TIMEOUT_MS,
- * and the underlying transport interface implementation timeouts, unless an error
- * occurs.
- *    Blocking Time = Max( timeoutMs parameter,
- *                         MQTT_RECV_POLLING_TIMEOUT_MS,
- *                         Transport interface send/recv implementation timeout )
+ * depends on the passed @p timeoutMs, the configuration macros, #MQTT_RECV_POLLING_TIMEOUT_MS
+ * and #MQTT_SEND_RETRY_TIMEOUT_MS, and the underlying transport interface implementation
+ * timeouts, unless an error occurs. The blocking period also depends on the execution time of the
+ * #MQTTEventCallback_t callback supplied to the library. It is recommended that the supplied
+ * #MQTTEventCallback_t callback does not contain blocking operations to prevent potential
+ * non-deterministic blocking period of the #MQTTProcess_Loop API call.
  *
  * @return #MQTTBadParameter if context is NULL;
  * #MQTTRecvFailed if a network error occurs during reception;
@@ -670,12 +670,12 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
  * run, unless an error occurs.
  *
  * @note Calling this function blocks the calling context for a time period that
- * depends on the passed @p timeoutMs, the configuration macro, #MQTT_RECV_POLLING_TIMEOUT_MS,
- * and the underlying transport interface implementation timeouts, unless an error
- * occurs.
- *    Blocking Time = Max( timeoutMs parameter,
- *                         MQTT_RECV_POLLING_TIMEOUT_MS,
- *                         Transport interface send/recv implementation timeout )
+ * depends on the passed @p timeoutMs, the configuration macros, #MQTT_RECV_POLLING_TIMEOUT_MS
+ * and #MQTT_SEND_RETRY_TIMEOUT_MS, and the underlying transport interface implementation
+ * timeouts, unless an error occurs. The blocking period also depends on the execution time of the
+ * #MQTTEventCallback_t callback supplied to the library. It is recommended that the supplied
+ * #MQTTEventCallback_t callback does not contain blocking operations to prevent potential
+ * non-deterministic blocking period of the #MQTReceive_Loop API call.
  *
  * @return #MQTTBadParameter if context is NULL;
  * #MQTTRecvFailed if a network error occurs during reception;

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -601,7 +601,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  *
  * @note If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then the timeout
  * passed to the API MUST be 0, and the #MQTT_RECV_POLLING_TIMEOUT_MS and
- * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0. With a dummy
+ * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0. Also, with the dummy
  * timer function, the #MQTT_ProcessLoop function does not handle keep-alive mechanism.
  *
  * @param[in] pContext Initialized and connected MQTT context.

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -599,11 +599,9 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  *
  * @note Passing a timeout value of 0 will run the loop for a single iteration.
  *
- * @note If a dummy timer function, #MQTTGetCurrentTimeFunc_t, is used, then the timeout
- * passed to the API MUST be 0, and the #MQTT_RECV_POLLING_TIMEOUT_MS and
- * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST also be set to 0. Also,
- * with the dummy timer function, the #MQTT_ProcessLoop function does not handle
- * keep-alive mechanism.
+ * @note If a dummy timer function, #MQTTGetCurrentTimeFunct_t, is passed to the library,
+ * then the keep-alive mechanism is not supported by the #MQTT_ProcessLoop API.
+ * In that case, the #MQTT_ReceiveLoop API function should be used instead.
  *
  * @param[in] pContext Initialized and connected MQTT context.
  * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -614,7 +614,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  * timeouts, unless an error occurs. The blocking period also depends on the execution time of the
  * #MQTTEventCallback_t callback supplied to the library. It is recommended that the supplied
  * #MQTTEventCallback_t callback does not contain blocking operations to prevent potential
- * non-deterministic blocking period of the #MQTTProcess_Loop API call.
+ * non-deterministic blocking period of the #MQTT_ProcessLoop API call.
  *
  * @return #MQTTBadParameter if context is NULL;
  * #MQTTRecvFailed if a network error occurs during reception;
@@ -675,7 +675,7 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
  * timeouts, unless an error occurs. The blocking period also depends on the execution time of the
  * #MQTTEventCallback_t callback supplied to the library. It is recommended that the supplied
  * #MQTTEventCallback_t callback does not contain blocking operations to prevent potential
- * non-deterministic blocking period of the #MQTReceive_Loop API call.
+ * non-deterministic blocking period of the #MQTT_ReceiveLoop API call.
  *
  * @return #MQTTBadParameter if context is NULL;
  * #MQTTRecvFailed if a network error occurs during reception;

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -598,9 +598,11 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  * alive.
  *
  * @note Passing a timeout value of 0 will run the loop for a single iteration.
- * If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then the timeout
+ *
+ * @note If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then the timeout
  * passed to the API MUST be 0, and the #MQTT_RECV_POLLING_TIMEOUT_MS and
- * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0.
+ * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0. With a dummy
+ * timer function, the #MQTT_ProcessLoop function does not handle keep-alive mechanism.
  *
  * @param[in] pContext Initialized and connected MQTT context.
  * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -599,7 +599,7 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  *
  * @note Passing a timeout value of 0 will run the loop for a single iteration.
  *
- * @note If a dummy timer function, #MQTTGetCurrentTimeFunct_t, is passed to the library,
+ * @note If a dummy timer function, #MQTTGetCurrentTimeFunc_t, is passed to the library,
  * then the keep-alive mechanism is not supported by the #MQTT_ProcessLoop API.
  * In that case, the #MQTT_ReceiveLoop API function should be used instead.
  *

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -599,10 +599,11 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  *
  * @note Passing a timeout value of 0 will run the loop for a single iteration.
  *
- * @note If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then the timeout
+ * @note If a dummy timer function, #MQTTGetCurrentTimeFunc_t, is used, then the timeout
  * passed to the API MUST be 0, and the #MQTT_RECV_POLLING_TIMEOUT_MS and
- * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0. Also, with the dummy
- * timer function, the #MQTT_ProcessLoop function does not handle keep-alive mechanism.
+ * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST also be set to 0. Also,
+ * with the dummy timer function, the #MQTT_ProcessLoop function does not handle
+ * keep-alive mechanism.
  *
  * @param[in] pContext Initialized and connected MQTT context.
  * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -60,7 +60,7 @@ struct MQTTDeserializedInfo;
 
 /**
  * @ingroup mqtt_callback_types
- * @brief Application provided callback to retrieve the current time in
+ * @brief Application provided function to query the current time in
  * milliseconds.
  *
  * @return The current time in milliseconds.
@@ -228,12 +228,13 @@ typedef struct MQTTDeserializedInfo
  *
  * This function must be called on a #MQTTContext_t before any other function.
  *
- * @note The #MQTTGetCurrentTimeFunc_t callback function must be defined. If
+ * @note The #MQTTGetCurrentTimeFunc_t function for querying time must be defined. If
  * there is no time implementation, it is the responsibility of the application
- * to provide a dummy function to always return 0, and provide 0 timeouts for
- * all calls to #MQTT_Connect, #MQTT_ProcessLoop, and #MQTT_ReceiveLoop. This
- * will result in loop functions running for a single iteration, and #MQTT_Connect
- * relying on #MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT to receive the CONNACK packet.
+ * to provide a dummy function to always return 0, provide 0 timeouts for
+ * all calls to #MQTT_Connect, #MQTT_ProcessLoop, and #MQTT_ReceiveLoop and configure
+ * the #MQTT_RECV_POLLING_TIMEOUT_MS and #MQTT_SEND_RETRY_TIMEOUT_MS configurations
+ * to be 0. This will result in loop functions running for a single iteration, and
+ * #MQTT_Connect relying on #MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT to receive the CONNACK packet.
  *
  * @param[in] pContext The context to initialize.
  * @param[in] pTransportInterface The transport interface to use with the context.
@@ -310,8 +311,9 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
  *    The network receive for CONNACK is retried up to the number of times
  *    configured by #MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT.
  *
- * @note If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then the
- * timeout MUST be set to 0.
+ * @note If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then a
+ * timeout value of 0 MUST be passed to the API, and the #MQTT_RECV_POLLING_TIMEOUT_MS
+ * and #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0.
  *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pConnectInfo MQTT CONNECT packet information.
@@ -596,8 +598,9 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext );
  * alive.
  *
  * @note Passing a timeout value of 0 will run the loop for a single iteration.
- * If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then this
- * timeout MUST be set to 0.
+ * If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then the timeout
+ * passed to the API MUST be 0, and the #MQTT_RECV_POLLING_TIMEOUT_MS and
+ * #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0.
  *
  * @param[in] pContext Initialized and connected MQTT context.
  * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will
@@ -656,8 +659,9 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
  * keep alive.
  *
  * @note Passing a timeout value of 0 will run the loop for a single iteration.
- * If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then this
- * timeout MUST be set to 0.
+ * If a dummy #MQTTGetCurrentTimeFunc_t was passed to #MQTT_Init, then the timeout
+ * value passed to the API MUST be 0, and the #MQTT_RECV_POLLING_TIMEOUT_MS
+ * and #MQTT_SEND_RETRY_TIMEOUT_MS timeout configurations MUST be set to 0.
  *
  * @param[in] pContext Initialized and connected MQTT context.
  * @param[in] timeoutMs Minimum time in milliseconds that the receive loop will

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -100,7 +100,7 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  *
- * @note If a dummy implementation of the #MQTTGetCurrentFunc_t timer function,
+ * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
  * that always returns zero, is supplied to the library, then the keep-alive
  * mechanism is not supported by the #MQTT_ProcessLoop API function. In that
  * case, the value of #MQTT_PINGRESP_TIMEOUT_MS is irrelevant to the behavior

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -101,10 +101,9 @@
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  *
  * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
- * that always returns zero, is supplied to the library, then the keep-alive
- * mechanism is not supported by the #MQTT_ProcessLoop API function. In that
- * case, the value of #MQTT_PINGRESP_TIMEOUT_MS is irrelevant to the behavior
- * of the library.
+ * is supplied to the library, then the keep-alive mechanism is not supported by the
+ * #MQTT_ProcessLoop API function. In that case, the value of #MQTT_PINGRESP_TIMEOUT_MS
+ * is irrelevant to the behavior of the library.
  *
  * <b>Possible values:</b> Any positive integer up to SIZE_MAX. <br>
  * <b>Default value:</b> `500`
@@ -128,8 +127,7 @@
  * return #MQTTRecvFailed.
  *
  * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
- * that always returns 0, is supplied to the library, then #MQTT_RECV_POLLING_TIMEOUT_MS
- * MUST be set to 0.
+ * is supplied to the library, then #MQTT_RECV_POLLING_TIMEOUT_MS MUST be set to 0.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. Recommended to use a
  * small timeout value. <br>
@@ -154,8 +152,7 @@
  * return #MQTTSendFailed.
  *
  * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
- * that always returns 0, is supplied to the library, then #MQTT_SEND_RETRY_TIMEOUT_MS
- * MUST be set to 0.
+ * is supplied to the library, then #MQTT_SEND_RETRY_TIMEOUT_MS MUST be set to 0.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. Recommended to use a small
  * timeout value. <br>

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -117,8 +117,12 @@
  * may be called multiple times until all of the expected number of bytes of the
  * packet are received. This timeout represents the maximum polling duration that
  * is allowed without any data reception from the network for the incoming packet.
+ *
  * If the timeout expires, the #MQTT_ProcessLoop and #MQTT_ReceiveLoop functions
  * return #MQTTRecvFailed.
+ *
+ * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
+ * that always returns 0, is used, then #MQTT_RECV_POLLING_TIMEOUT_MS MUST be set to 0.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. Recommended to use a
  * small timeout value. <br>
@@ -141,6 +145,9 @@
  *
  * If the timeout expires, the #MQTT_ProcessLoop and #MQTT_ReceiveLoop functions
  * return #MQTTSendFailed.
+ *
+ * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
+ * that always returns 0, is used, then #MQTT_SEND_RETRY_TIMEOUT_MS MUST be set to 0.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. Recommended to use a small
  * timeout value. <br>

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -100,6 +100,12 @@
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  *
+ * @note If a dummy implementation of the #MQTTGetCurrentFunc_t timer function,
+ * that always returns zero, is supplied to the library, then the keep-alive
+ * mechanism is not supported by the #MQTT_ProcessLoop API function. In that
+ * case, the value of #MQTT_PINGRESP_TIMEOUT_MS is irrelevant to the behavior
+ * of the library.
+ *
  * <b>Possible values:</b> Any positive integer up to SIZE_MAX. <br>
  * <b>Default value:</b> `500`
  */
@@ -122,7 +128,8 @@
  * return #MQTTRecvFailed.
  *
  * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
- * that always returns 0, is used, then #MQTT_RECV_POLLING_TIMEOUT_MS MUST be set to 0.
+ * that always returns 0, is supplied to the library, then #MQTT_RECV_POLLING_TIMEOUT_MS
+ * MUST be set to 0.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. Recommended to use a
  * small timeout value. <br>
@@ -147,7 +154,8 @@
  * return #MQTTSendFailed.
  *
  * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
- * that always returns 0, is used, then #MQTT_SEND_RETRY_TIMEOUT_MS MUST be set to 0.
+ * that always returns 0, is supplied to the library, then #MQTT_SEND_RETRY_TIMEOUT_MS
+ * MUST be set to 0.
  *
  * <b>Possible values:</b> Any positive 32 bit integer. Recommended to use a small
  * timeout value. <br>


### PR DESCRIPTION
Update API doc to mention that the **keep-alive** mechanism is not supported by `MQTT_ProcessLoop` API when a dummy timer function that always returns zero is supplied to the library.