### PR TITLE
Update memory numbers in Doxygen to be in sync with FreeRTOS.org

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -41,7 +41,7 @@ Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main/demos/
         <td><center>2.0K</center></td>
     </tr>
     <tr>
-        <td><b>Total estimates</b></td>
+        <td><b>Total estimate</b></td>
         <td><center><b>6.9K</b></center></td>
         <td><center><b>5.7K</b></center></td>
     </tr>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -18,7 +18,7 @@ Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main/demos/
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code size of coreMQTT (example generated with GCC for ARM Cortex-M toolchain)</b></center></td>
+        <td colspan="4"><center><b>Code size of coreMQTT (example generated with GCC for ARM Cortex-M)</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -18,7 +18,7 @@ Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main/demos/
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code size of coreMQTT (example generated with GCC for ARM Cortex-M)</b></center></td>
+        <td colspan="3"><center><b>Code size of coreMQTT (example generated with GCC for ARM Cortex-M)</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -18,37 +18,32 @@ Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main/demos/
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code size of coreMQTT library files (sizes generated with [GCC for ARM Cortex-M toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2020-q2-update))</b></center></td>
+        <td colspan="4"><center><b>Code size of coreMQTT (example generated with GCC for ARM Cortex-M toolchain)</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>No Optimization (asserts enabled)</b></td>
-        <td><b>With -O1 Optimization (asserts disabled)</b></td>
-        <td><b>With -Os Optimization (asserts disabled)</b></td>
+        <td><center><b>With -O1 Optimization</b></center></td>
+        <td><center><b>With -Os Optimization</b></center></td>
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td>13.6K</td>
-        <td>6.9K</td>
-        <td>6.3K</td>
+        <td><center>3.0K</center></td>
+        <td><center>2.6K</center></td>
     </tr>
     <tr>
         <td>core_mqtt_state.c</td>
-        <td>6.0K</td>
-        <td>3.0K</td>
-        <td>2.3K</td>
+        <td><center>1.4K</center></td>
+        <td><center>1.1K</center></td>
     </tr>
     <tr>
         <td>core_mqtt_serializer.c</td>
-        <td>12.3K</td>
-        <td>5.6K</td>
-        <td>5.1K</td>
+        <td><center>2.5K</center></td>
+        <td><center>2.0K</center></td>
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td>31.9K</td>
-        <td>15.5K</td>
-        <td>13.7K</td>
+        <td><center><b>6.9K</b></center></td>
+        <td><center><b>5.7K</b></center></td>
     </tr>
 </table>
  */


### PR DESCRIPTION
Update memory numbers in Doxygen to be in sync with FreeRTOS.org
at https://www.freertos.org/mqtt/index.html
