### PR TITLE
Use coverage check GH action in CI unittest job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,24 +34,9 @@ jobs:
           echo ${EXCLUDE[@]} | xargs lcov --rc lcov_branch_coverage=1 -r build/coverage.info -o build/coverage.info
           lcov --rc lcov_branch_coverage=1 --list build/coverage.info
       - name: Check Coverage
-        env:
-          MIN_COVERAGE: 100
-        run: |
-          LINE_COVERAGE=$(lcov --list build/coverage.info | tail -n 1 | cut -d '|' -f 2 | sed -n "s/\([^%]*\)%.*/\1/p")
-          BRANCH_COVERAGE=$(lcov --rc lcov_branch_coverage=1 --list build/coverage.info | tail -n 1 | cut -d '|' -f 4 | sed -n "s/\([^%]*\)%.*/\1/p")
-          RESULT=0
-          echo "Required line and branch coverages: $MIN_COVERAGE"
-          echo "Line coverage:   $LINE_COVERAGE"
-          if [[ $(echo "$LINE_COVERAGE < $MIN_COVERAGE" | bc) -ne 0 ]]; then
-            echo "Line Coverage is too low."
-            RESULT=1
-          fi
-          echo "Branch coverage: $BRANCH_COVERAGE"
-          if [[ $(echo "$BRANCH_COVERAGE < $MIN_COVERAGE" | bc) -ne 0 ]]; then
-            echo "Branch Coverage is too low."
-            RESULT=1
-          fi
-          exit $RESULT
+        uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
+        with:
+          path: ./build/coverage.info
   complexity:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Use the `coverage-cop` custom GitHub action for coverage compliance check of branch and line coverages of unit tests.