### PR TITLE
Add workflow to generate doxygen size tables

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,6 +32,7 @@ To send us a pull request, please:
 1. Fork the repository.
 1. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 1. Ensure that your contributions conform to the [style guide](https://docs.aws.amazon.com/embedded-csdk/202011.00/lib-ref/docs/doxygen/output/html/guide_developer_styleguide.html).
+1. Format your code with uncrustify, using the config available in [FreeRTOS/CI-CD-Github-Actions](https://github.com/FreeRTOS/CI-CD-Github-Actions/blob/main/formatting/uncrustify.cfg).
 1. Ensure local tests pass.
 1. Commit to your fork using clear commit messages.
 1. Send us a pull request, answering any default questions in the pull request interface.

--- a/.github/memory_statistics_config.json
+++ b/.github/memory_statistics_config.json
@@ -1,0 +1,15 @@
+{
+    "lib_name": "coreMQTT",
+    "src": [
+        "source/core_mqtt.c",
+        "source/core_mqtt_state.c",
+        "source/core_mqtt_serializer.c"
+    ],
+    "include": [
+        "source/include",
+        "source/interface"
+    ],
+    "compiler_flags": [
+        "MQTT_DO_NOT_USE_CUSTOM_CONFIG"
+    ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,14 @@ jobs:
           -DBUILD_CLONE_SUBMODULES=ON \
           -DCMAKE_C_FLAGS='-Wall -Wextra -I../override-include'
           make -C build/ coverity_analysis
+  memory_statistics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            submodules: 'recursive'
+      - name: Measure sizes
+        uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
+        with:
+            config: .github/memory_statistics_config.json
+            check_against: docs/doxygen/include/size_table.html

--- a/.github/workflows/memory_statistics.yml
+++ b/.github/workflows/memory_statistics.yml
@@ -1,0 +1,31 @@
+name: Memory statistics
+
+on:
+  workflow_dispatch:
+
+jobs:
+  memory_statistics:
+    name: Calculate object sizes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            submodules: 'recursive'
+      - name: Measure sizes
+        uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
+        with:
+          lib_name: coreMQTT
+          src: |
+            source/core_mqtt.c
+            source/core_mqtt_state.c
+            source/core_mqtt_serializer.c
+          include: |
+            source/include
+            source/interface
+          compiler_flags: |
+            MQTT_DO_NOT_USE_CUSTOM_CONFIG
+      - name: Upload table
+        uses: actions/upload-artifact@v2
+        with:
+          name: size_table
+          path: size_table.html

--- a/.github/workflows/memory_statistics.yml
+++ b/.github/workflows/memory_statistics.yml
@@ -14,16 +14,7 @@ jobs:
       - name: Measure sizes
         uses: FreeRTOS/CI-CD-Github-Actions/memory_statistics@main
         with:
-          lib_name: coreMQTT
-          src: |
-            source/core_mqtt.c
-            source/core_mqtt_state.c
-            source/core_mqtt_serializer.c
-          include: |
-            source/include
-            source/interface
-          compiler_flags: |
-            MQTT_DO_NOT_USE_CUSTOM_CONFIG
+            config: .github/memory_statistics_config.json
       - name: Upload table
         uses: actions/upload-artifact@v2
         with:

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -924,7 +924,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = source/include
+EXAMPLE_PATH           = source/include docs/doxygen/include
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -1,0 +1,30 @@
+<table>
+    <tr>
+        <td colspan="3"><center><b>Code Size of coreMQTT (example generated with GCC for ARM Cortex-M)</b></center></td>
+    </tr>
+    <tr>
+        <td><b>File</b></td>
+        <td><b><center>With -O1 Optimization</center></b></td>
+        <td><b><center>With -Os Optimization</center></b></td>
+    </tr>
+    <tr>
+        <td>core_mqtt.c</td>
+        <td><center>3.0K</center></td>
+        <td><center>2.6K</center></td>
+    </tr>
+    <tr>
+        <td>core_mqtt_state.c</td>
+        <td><center>1.4K</center></td>
+        <td><center>1.1K</center></td>
+    </tr>
+    <tr>
+        <td>core_mqtt_serializer.c</td>
+        <td><center>2.5K</center></td>
+        <td><center>2.0K</center></td>
+    </tr>
+    <tr>
+        <td><b>Total estimates</b></td>
+        <td><b><center>6.9K</center></b></td>
+        <td><b><center>5.7K</center></b></td>
+    </tr>
+</table>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -16,36 +16,7 @@ Please see https://github.com/aws/aws-iot-device-sdk-embedded-C/tree/main/demos/
 @section mqtt_memory_requirements Memory Requirements
 @brief Memory requirements of the MQTT library.
 
-<table>
-    <tr>
-        <td colspan="3"><center><b>Code size of coreMQTT (example generated with GCC for ARM Cortex-M)</b></center></td>
-    </tr>
-    <tr>
-        <td><b>File</b></td>
-        <td><center><b>With -O1 Optimization</b></center></td>
-        <td><center><b>With -Os Optimization</b></center></td>
-    </tr>
-    <tr>
-        <td>core_mqtt.c</td>
-        <td><center>3.0K</center></td>
-        <td><center>2.6K</center></td>
-    </tr>
-    <tr>
-        <td>core_mqtt_state.c</td>
-        <td><center>1.4K</center></td>
-        <td><center>1.1K</center></td>
-    </tr>
-    <tr>
-        <td>core_mqtt_serializer.c</td>
-        <td><center>2.5K</center></td>
-        <td><center>2.0K</center></td>
-    </tr>
-    <tr>
-        <td><b>Total estimate</b></td>
-        <td><center><b>6.9K</b></center></td>
-        <td><center><b>5.7K</b></center></td>
-    </tr>
-</table>
+@include{doc} size_table.html
  */
 
 /**


### PR DESCRIPTION
Adds a manual workflow that calls the memory statistics action to generate a size table.
Additionally refactors the doxygen table into its own file to make updating it easier.