### PR TITLE
Fix keep alive checking interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for coreMQTT Client Library
 
+## Commits to `main`
+
+### Updates
+ - [#163](https://github.com/FreeRTOS/coreMQTT/pull/163) Fix bug to check for ping responses within `MQTT_PINGRESP_TIMEOUT_MS` instead of the entire keep alive interval
+
 ## v1.1.1 (February 2021)
 
 ### Changes

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td><center>3.0K</center></td>
+        <td><center>3.1K</center></td>
         <td><center>2.6K</center></td>
     </tr>
     <tr>
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>6.9K</center></b></td>
+        <td><b><center>7.0K</center></b></td>
         <td><b><center>5.7K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/include/size_table.html
+++ b/docs/doxygen/include/size_table.html
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td><center>3.1K</center></td>
+        <td><center>3.0K</center></td>
         <td><center>2.6K</center></td>
     </tr>
     <tr>
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>7.0K</center></b></td>
+        <td><b><center>6.9K</center></b></td>
         <td><b><center>5.7K</center></b></td>
     </tr>
 </table>

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -995,6 +995,7 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
 {
     MQTTStatus_t status = MQTTSuccess;
     uint32_t now = 0U, keepAliveMs = 0U;
+    uint32_t pingrespTimeoutMs = MQTT_PINGRESP_TIMEOUT_MS;
 
     assert( pContext != NULL );
     assert( pContext->getTime != NULL );
@@ -1002,22 +1003,30 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
     now = pContext->getTime();
     keepAliveMs = 1000U * ( uint32_t ) pContext->keepAliveIntervalSec;
 
+    /* It is not useful for the ping response timeout to be greater than half
+     * the keep alive, as the server will have disconnected us by that point. */
+    if( pingrespTimeoutMs > ( keepAliveMs / 2 ) )
+    {
+        pingrespTimeoutMs = keepAliveMs / 2;
+    }
+
     /* If keep alive interval is 0, it is disabled. */
-    if( ( keepAliveMs != 0U ) &&
-        ( calculateElapsedTime( now, pContext->lastPacketTime ) > keepAliveMs ) )
+    if( keepAliveMs != 0U )
     {
         if( pContext->waitingForPingResp == true )
         {
             /* Has time expired? */
-            if( calculateElapsedTime( now, pContext->pingReqSendTimeMs ) >
-                MQTT_PINGRESP_TIMEOUT_MS )
+            if( calculateElapsedTime( now, pContext->pingReqSendTimeMs ) > pingrespTimeoutMs )
             {
                 status = MQTTKeepAliveTimeout;
             }
         }
         else
         {
-            status = MQTT_Ping( pContext );
+            if( calculateElapsedTime( now, pContext->lastPacketTime ) > keepAliveMs )
+            {
+                status = MQTT_Ping( pContext );
+            }
         }
     }
 

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -995,7 +995,6 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
 {
     MQTTStatus_t status = MQTTSuccess;
     uint32_t now = 0U, keepAliveMs = 0U;
-    uint32_t pingrespTimeoutMs = MQTT_PINGRESP_TIMEOUT_MS;
 
     assert( pContext != NULL );
     assert( pContext->getTime != NULL );
@@ -1003,20 +1002,14 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
     now = pContext->getTime();
     keepAliveMs = 1000U * ( uint32_t ) pContext->keepAliveIntervalSec;
 
-    /* It is not useful for the ping response timeout to be greater than half
-     * the keep alive, as the server will have disconnected us by that point. */
-    if( pingrespTimeoutMs > ( keepAliveMs / 2 ) )
-    {
-        pingrespTimeoutMs = keepAliveMs / 2;
-    }
-
     /* If keep alive interval is 0, it is disabled. */
     if( keepAliveMs != 0U )
     {
         if( pContext->waitingForPingResp == true )
         {
             /* Has time expired? */
-            if( calculateElapsedTime( now, pContext->pingReqSendTimeMs ) > pingrespTimeoutMs )
+            if( calculateElapsedTime( now, pContext->pingReqSendTimeMs ) >
+                MQTT_PINGRESP_TIMEOUT_MS )
             {
                 status = MQTTKeepAliveTimeout;
             }

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -106,11 +106,11 @@
  * is irrelevant to the behavior of the library.
  *
  * <b>Possible values:</b> Any positive integer up to SIZE_MAX. <br>
- * <b>Default value:</b> `500`
+ * <b>Default value:</b> `5000`
  */
 #ifndef MQTT_PINGRESP_TIMEOUT_MS
-    /* Wait 0.5 seconds by default for a ping response. */
-    #define MQTT_PINGRESP_TIMEOUT_MS    ( 500U )
+    /* Wait 5 seconds by default for a ping response. */
+    #define MQTT_PINGRESP_TIMEOUT_MS    ( 5000U )
 #endif
 
 /**

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -94,11 +94,15 @@
 #endif
 
 /**
- * @brief Number of milliseconds to wait for a ping response to a ping
+ * @brief Maximum number of milliseconds to wait for a ping response to a ping
  * request as part of the keep-alive mechanism.
  *
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
+ *
+ * @note If this value is more than half of the keep alive interval, and the
+ * server does not receive the previous ping request, then it is likely that the
+ * server will disconnect the client before #MQTTKeepAliveTimeout can be returned.
  *
  * @note If a dummy implementation of the #MQTTGetCurrentTimeFunc_t timer function,
  * is supplied to the library, then the keep-alive mechanism is not supported by the

--- a/test/cbmc/include/core_mqtt_config.h
+++ b/test/cbmc/include/core_mqtt_config.h
@@ -68,7 +68,7 @@ struct NetworkContext
  * If a ping response is not received before this timeout, then
  * #MQTT_ProcessLoop will return #MQTTKeepAliveTimeout.
  */
-#define MQTT_PINGRESP_TIMEOUT_MS                ( 500U )
+#define MQTT_PINGRESP_TIMEOUT_MS                ( 5000U )
 
 /**
  * @brief The maximum duration of receiving no data over network when

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1943,11 +1943,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = true;
-
-    /* Use a large keep alive interval for this test so that the ping response
-     * timeout will be #MQTT_PINGRESP_TIMEOUT_MS and not keep alive interval / 2.
-     * We use 4 * ping response timeout, so timeout / 1000 * 4 = timeout / 250. */
-    context.keepAliveIntervalSec = MQTT_PINGRESP_TIMEOUT_MS / 250;
+    context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
     context.lastPacketTime = MQTT_ONE_SECOND_TO_MS;
     context.pingReqSendTimeMs = MQTT_ONE_SECOND_TO_MS;
     /* Set expected return values in the loop. All success. */
@@ -1981,7 +1977,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     setupTransportInterface( &transport );
 
     modifyIncomingPacketStatus = MQTTNoDataAvailable;
-    globalEntryTime = MQTT_ONE_SECOND_TO_MS;
+    globalEntryTime = MQTT_PINGRESP_TIMEOUT_MS + 1;
 
     /* Coverage for the branch path where PINGRESP timeout interval has expired. */
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1943,7 +1943,11 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = true;
-    context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
+
+    /* Use a large keep alive interval for this test so that the ping response
+     * timeout will be #MQTT_PINGRESP_TIMEOUT_MS and not keep alive interval / 2.
+     * We use 4 * ping response timeout, so timeout / 1000 * 4 = timeout / 250. */
+    context.keepAliveIntervalSec = MQTT_PINGRESP_TIMEOUT_MS / 250;
     context.lastPacketTime = MQTT_ONE_SECOND_TO_MS;
     context.pingReqSendTimeMs = MQTT_ONE_SECOND_TO_MS;
     /* Set expected return values in the loop. All success. */

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -491,7 +491,7 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
     {
         if( ( pContext->waitingForPingResp == false ) &&
             ( pContext->keepAliveIntervalSec != 0U ) &&
-            ( globalEntryTime - pContext->lastPacketTime ) > ( 1000U * pContext->keepAliveIntervalSec ) )
+            ( ( globalEntryTime - pContext->lastPacketTime ) > ( 1000U * pContext->keepAliveIntervalSec ) ) )
         {
             MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
             /* Replace pointer parameter being passed to the method. */


### PR DESCRIPTION
*Description*:
As pointed out in https://forums.freertos.org/t/keepalivetimeout-code-in-coremqtt/12957/3, when a ping request is sent from `MQTT_ProcessLoop()`, it is only checked for a response after the keep alive interval has elapsed again. Since the broker would have disconnected the client by that time anyway if the PINGREQ was not received, the response ought to be checked earlier, as dictated by `MQTT_PINGRESP_TIMEOUT_MS`.

Two solutions for this issue are:
1. Update `handleKeepAlive` to check based on `pingReqSendTimeMs` and not `lastPacketTimeMs`.
2. Update `MQTT_Ping()` to only update `pingReqSendTimeMs` and not `lastPacketTimeMs`.

The latter solution would mean that sending other packets, e.g. a PUBLISH, would reset the interval before the PINGRESP is checked, while in the former it would not. ~However, the latter solution results in a smaller binary when optimizing with `-O1`~. This PR implements the former solution, and leaves discussion for the tradeoffs for this review
