### PR TITLE
Handle all enum values in switches

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -922,6 +922,13 @@ static uint8_t getAckTypeToSend( MQTTPublishState_t state )
             packetTypeByte = MQTT_PACKET_TYPE_PUBCOMP;
             break;
 
+        case MQTTPubAckPending:
+        case MQTTPubCompPending:
+        case MQTTPubRecPending:
+        case MQTTPubRelPending:
+        case MQTTPublishDone:
+        case MQTTPublishSend:
+        case MQTTStateNull:
         default:
             /* Take no action for states that do not require sending an ack. */
             break;

--- a/source/core_mqtt_state.c
+++ b/source/core_mqtt_state.c
@@ -246,6 +246,7 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
                     isValid = ( newState == MQTTPubRecPending ) ? true : false;
                     break;
 
+                case MQTTQoS0:
                 default:
                     /* QoS 0 is checked before calling this function. */
                     break;
@@ -271,6 +272,13 @@ static bool validateTransitionPublish( MQTTPublishState_t currentState,
 
             break;
 
+        case MQTTPubAckSend:
+        case MQTTPubCompPending:
+        case MQTTPubCompSend:
+        case MQTTPubRecSend:
+        case MQTTPubRelPending:
+        case MQTTPubRelSend:
+        case MQTTPublishDone:
         default:
             /* For a PUBLISH, we should not start from any other state. */
             break;


### PR DESCRIPTION
Non-functional change to handle all enum values for MQTTPublishState_t and MQTTQoS_t in switch statements. This allows users to compile with -Werror=switch-enum.