### PR TITLE
Fix release workflow doxygen generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
           path: zip-check/coreMQTT-${{ github.event.inputs.version_number }}.zip
   deploy-doxygen:
     needs: tag-commit
+    if: ${{ ( github.event.inputs.delete_existing_tag_release == 'true' && success() )  || ( github.event.inputs.delete_existing_tag_release == 'false' && always() ) }}
     name: Deploy doxygen documentation
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Since coreMQTT and coreMQTT-Agent have a different release.yml, they require an if line or doxygen generation is skipped.