### PR TITLE
generate PINGREQ packets on idle input or output.

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,8 +9,8 @@
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td><center>3.0K</center></td>
-        <td><center>2.6K</center></td>
+        <td><center>3.1K</center></td>
+        <td><center>2.7K</center></td>
     </tr>
     <tr>
         <td>core_mqtt_state.c</td>
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>6.9K</center></b></td>
-        <td><b><center>5.7K</center></b></td>
+        <td><b><center>7.0K</center></b></td>
+        <td><b><center>5.8K</center></b></td>
     </tr>
 </table>

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -133,7 +133,7 @@ In this library, @ref mqtt_processloop_function handles sending of PINGREQs and 
 The standard does not specify the time duration within which the server has to respond to a ping request, noting only a "reasonable amount of time". If the response to a ping request is not received within @ref MQTT_PINGRESP_TIMEOUT_MS, this library assumes that the connection is dead.
 
 If @ref mqtt_receiveloop_function is used instead of @ref mqtt_processloop_function, then no ping requests are sent. The application must ensure the connection does not remain idle for more than the keep-alive interval by calling @ref mqtt_ping_function to send ping requests.
-The timestamp in @ref MQTTContext_t.lastPacketTime indicates when a packet was last sent by the library.
+The timestamp in @ref MQTTContext_t.lastPacketTxTime indicates when a packet was last sent by the library.
 
 Sending any ping request sets the @ref MQTTContext_t.waitingForPingResp flag. This flag is cleared by @ref mqtt_processloop_function when a ping response is received. If @ref mqtt_receiveloop_function is used instead, then this flag must be cleared manually by the application's callback.
 */

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -118,7 +118,7 @@ iso
 keepaliveintervalsec
 keepalivems
 keepaliveseconds
-lastpackettime
+lastpackettxtime
 linux
 logdebug
 logerror

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -318,6 +318,7 @@ resending
 reservestate
 responsecode
 rm
+rx
 sdk
 searchstates
 sendpacket

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1008,11 +1008,14 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
     assert( pContext->getTime != NULL );
 
     now = pContext->getTime();
-    packetTxTimeoutMs = 1000U * ( uint32_t ) pContext->keepAliveIntervalSec;
 
     if( PACKET_TX_TIMEOUT_MS < packetTxTimeoutMs )
     {
         packetTxTimeoutMs = PACKET_TX_TIMEOUT_MS;
+    }
+    else
+    {
+        packetTxTimeoutMs = 1000U * ( uint32_t ) pContext->keepAliveIntervalSec;
     }
 
     /* If keep alive interval is 0, it is disabled. */

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1035,9 +1035,9 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
         else if( ( PACKET_RX_TIMEOUT_MS != 0U ) && ( calculateElapsedTime( now, pContext->lastPacketRxTime ) >= PACKET_RX_TIMEOUT_MS ) )
         {
             status = MQTT_Ping( pContext );
-        } else
+        }
+        else
         {
-            /* NOP */
         }
     }
 

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1002,7 +1002,7 @@ static MQTTStatus_t sendPublishAcks( MQTTContext_t * pContext,
 static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
 {
     MQTTStatus_t status = MQTTSuccess;
-    uint32_t now = 0U, packetTxTimeoutMs = 0U, packetRxTimeoutMs = 0U;
+    uint32_t now = 0U, packetTxTimeoutMs = 0U;
 
     assert( pContext != NULL );
     assert( pContext->getTime != NULL );

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1035,7 +1035,9 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
         else if( ( PACKET_RX_TIMEOUT_MS != 0U ) && ( calculateElapsedTime( now, pContext->lastPacketRxTime ) >= PACKET_RX_TIMEOUT_MS ) )
         {
             status = MQTT_Ping( pContext );
-        } else {
+        } else
+        {
+            /* NOP */
         }
     }
 

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1008,7 +1008,12 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
     assert( pContext->getTime != NULL );
 
     now = pContext->getTime();
-    packetTxTimeoutMs = MIN(PACKET_TX_TIMEOUT_MS, 1000U * ( uint32_t ) pContext->keepAliveIntervalSec);
+    packetTxTimeoutMs = 1000U * ( uint32_t ) pContext->keepAliveIntervalSec;
+
+    if( PACKET_TX_TIMEOUT_MS < packetTxTimeoutMs )
+    {
+        packetTxTimeoutMs = PACKET_TX_TIMEOUT_MS;
+    }
 
     /* If keep alive interval is 0, it is disabled. */
     if( pContext->waitingForPingResp == true )
@@ -1022,11 +1027,11 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
     }
     else
     {
-        if((packetTxTimeoutMs != 0U) && (calculateElapsedTime( now, pContext->lastPacketTxTime ) >= packetTxTimeoutMs) )
+        if( ( packetTxTimeoutMs != 0U ) && ( calculateElapsedTime( now, pContext->lastPacketTxTime ) >= packetTxTimeoutMs ) )
         {
             status = MQTT_Ping( pContext );
         }
-        else if((PACKET_RX_TIMEOUT_MS != 0U) && ( calculateElapsedTime( now, pContext->lastPacketRxTime) >= PACKET_RX_TIMEOUT_MS) )
+        else if( ( PACKET_RX_TIMEOUT_MS != 0U ) && ( calculateElapsedTime( now, pContext->lastPacketRxTime ) >= PACKET_RX_TIMEOUT_MS ) )
         {
             status = MQTT_Ping( pContext );
         }

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1009,13 +1009,11 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
 
     now = pContext->getTime();
 
+    packetTxTimeoutMs = 1000U * ( uint32_t ) pContext->keepAliveIntervalSec;
+
     if( PACKET_TX_TIMEOUT_MS < packetTxTimeoutMs )
     {
         packetTxTimeoutMs = PACKET_TX_TIMEOUT_MS;
-    }
-    else
-    {
-        packetTxTimeoutMs = 1000U * ( uint32_t ) pContext->keepAliveIntervalSec;
     }
 
     /* If keep alive interval is 0, it is disabled. */

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1035,6 +1035,7 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
         else if( ( PACKET_RX_TIMEOUT_MS != 0U ) && ( calculateElapsedTime( now, pContext->lastPacketRxTime ) >= PACKET_RX_TIMEOUT_MS ) )
         {
             status = MQTT_Ping( pContext );
+        } else {
         }
     }
 

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -213,6 +213,11 @@ typedef struct MQTTContext
     uint32_t lastPacketTime;
 
     /**
+     * @brief Timestamp of the last packet received by the library.
+     */
+    uint32_t lastPacketReceivedTime;
+
+    /**
      * @brief Whether the library sent a packet during a call of #MQTT_ProcessLoop or
      * #MQTT_ReceiveLoop.
      */

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -224,9 +224,10 @@ typedef struct MQTTContext
     bool controlPacketSent;
 
     /* Keep alive members. */
-    uint16_t keepAliveIntervalSec; /**< @brief Keep Alive interval. */
-    uint32_t pingReqSendTimeMs;    /**< @brief Timestamp of the last sent PINGREQ. */
-    bool waitingForPingResp;       /**< @brief If the library is currently awaiting a PINGRESP. */
+    uint16_t keepAliveIntervalSec;    /**< @brief Keep Alive interval. */
+    uint16_t packetRxTimeoutSec;      /**< @brief Packet Receive timeout. */
+    uint32_t pingReqSendTimeMs;       /**< @brief Timestamp of the last sent PINGREQ. */
+    bool waitingForPingResp;          /**< @brief If the library is currently awaiting a PINGRESP. */
 } MQTTContext_t;
 
 /**

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -37,8 +37,8 @@
  * without a custom config. If a custom config is provided, the
  * MQTT_DO_NOT_USE_CUSTOM_CONFIG macro should not be defined. */
 #ifndef MQTT_DO_NOT_USE_CUSTOM_CONFIG
-    /* Include custom config file before other headers. */
-    #include "core_mqtt_config.h"
+/* Include custom config file before other headers. */
+#include "core_mqtt_config.h"
 #endif
 
 /* Include config defaults header to get default values of configs not

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -224,10 +224,9 @@ typedef struct MQTTContext
     bool controlPacketSent;
 
     /* Keep alive members. */
-    uint16_t keepAliveIntervalSec;    /**< @brief Keep Alive interval. */
-    uint16_t packetRxTimeoutSec;      /**< @brief Packet Receive timeout. */
-    uint32_t pingReqSendTimeMs;       /**< @brief Timestamp of the last sent PINGREQ. */
-    bool waitingForPingResp;          /**< @brief If the library is currently awaiting a PINGRESP. */
+    uint16_t keepAliveIntervalSec; /**< @brief Keep Alive interval. */
+    uint32_t pingReqSendTimeMs;    /**< @brief Timestamp of the last sent PINGREQ. */
+    bool waitingForPingResp;       /**< @brief If the library is currently awaiting a PINGRESP. */
 } MQTTContext_t;
 
 /**

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -725,7 +725,7 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
  *      {
  *          // Since this function does not send pings, the application may need
  *          // to in order to comply with keep alive.
- *          if( ( pContext->getTime() - pContext->lastPacketTime ) > keepAliveMs )
+ *          if( ( pContext->getTime() - pContext->lastPacketTxTime ) > keepAliveMs )
  *          {
  *              status = MQTT_Ping( pContext );
  *          }

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -210,12 +210,12 @@ typedef struct MQTTContext
     /**
      * @brief Timestamp of the last packet sent by the library.
      */
-    uint32_t lastPacketTime;
+    uint32_t lastPacketTxTime;
 
     /**
      * @brief Timestamp of the last packet received by the library.
      */
-    uint32_t lastPacketReceivedTime;
+    uint32_t lastPacketRxTime;
 
     /**
      * @brief Whether the library sent a packet during a call of #MQTT_ProcessLoop or

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -38,7 +38,7 @@
  * MQTT_DO_NOT_USE_CUSTOM_CONFIG macro should not be defined. */
 #ifndef MQTT_DO_NOT_USE_CUSTOM_CONFIG
 /* Include custom config file before other headers. */
-#include "core_mqtt_config.h"
+    #include "core_mqtt_config.h"
 #endif
 
 /* Include config defaults header to get default values of configs not

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -146,7 +146,7 @@
  *
  */
 #ifndef PACKET_RX_TIMEOUT_MS
-    #define PACKET_RX_TIMEOUT_MS    ( 30000U )
+    #define PACKET_RX_TIMEOUT_MS    ( 25000U )
 #endif
 
 /**

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -146,7 +146,7 @@
  *
  */
 #ifndef PACKET_RX_TIMEOUT_MS
-    #define PACKET_RX_TIMEOUT_MS    ( 25000U )
+    #define PACKET_RX_TIMEOUT_MS    ( 30000U )
 #endif
 
 /**

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -55,7 +55,7 @@
  * be defined.
  */
 #ifdef DOXYGEN
-#define MQTT_DO_NOT_USE_CUSTOM_CONFIG
+    #define MQTT_DO_NOT_USE_CUSTOM_CONFIG
 #endif
 
 /**
@@ -79,7 +79,7 @@
  */
 #ifndef MQTT_STATE_ARRAY_MAX_COUNT
 /* Default value for the maximum acknowledgment pending PUBLISH messages. */
-#define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
+    #define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 #endif
 
 /**
@@ -96,7 +96,7 @@
  */
 #ifndef MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT
 /* Default value for the CONNACK receive retries. */
-#define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 5U )
+    #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 5U )
 #endif
 
 /**
@@ -120,7 +120,7 @@
  */
 #ifndef MQTT_PINGRESP_TIMEOUT_MS
 /* Wait 5 seconds by default for a ping response. */
-#define MQTT_PINGRESP_TIMEOUT_MS    ( 5000U )
+    #define MQTT_PINGRESP_TIMEOUT_MS    ( 5000U )
 #endif
 
 /**
@@ -134,7 +134,7 @@
  * <b>Default value:</b> '30000'
  */
 #ifndef PACKET_TX_TIMEOUT_MS
-#define PACKET_TX_TIMEOUT_MS    ( 30000U )
+    #define PACKET_TX_TIMEOUT_MS    ( 30000U )
 #endif
 
 /**
@@ -146,7 +146,7 @@
  *
  */
 #ifndef PACKET_RX_TIMEOUT_MS
-#define PACKET_RX_TIMEOUT_MS    ( 30000U )
+    #define PACKET_RX_TIMEOUT_MS    ( 30000U )
 #endif
 
 /**
@@ -171,7 +171,7 @@
  *
  */
 #ifndef MQTT_RECV_POLLING_TIMEOUT_MS
-#define MQTT_RECV_POLLING_TIMEOUT_MS    ( 10U )
+    #define MQTT_RECV_POLLING_TIMEOUT_MS    ( 10U )
 #endif
 
 /**
@@ -196,7 +196,7 @@
  *
  */
 #ifndef MQTT_SEND_RETRY_TIMEOUT_MS
-#define MQTT_SEND_RETRY_TIMEOUT_MS    ( 10U )
+    #define MQTT_SEND_RETRY_TIMEOUT_MS    ( 10U )
 #endif
 
 /* *INDENT-OFF* */

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -55,7 +55,7 @@
  * be defined.
  */
 #ifdef DOXYGEN
-    #define MQTT_DO_NOT_USE_CUSTOM_CONFIG
+#define MQTT_DO_NOT_USE_CUSTOM_CONFIG
 #endif
 
 /**
@@ -78,8 +78,8 @@
  * <b>Default value:</b> `10`
  */
 #ifndef MQTT_STATE_ARRAY_MAX_COUNT
-    /* Default value for the maximum acknowledgment pending PUBLISH messages. */
-    #define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
+/* Default value for the maximum acknowledgment pending PUBLISH messages. */
+#define MQTT_STATE_ARRAY_MAX_COUNT    ( 10U )
 #endif
 
 /**
@@ -95,8 +95,8 @@
  * <b>Default value:</b> `5`
  */
 #ifndef MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT
-    /* Default value for the CONNACK receive retries. */
-    #define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 5U )
+/* Default value for the CONNACK receive retries. */
+#define MQTT_MAX_CONNACK_RECEIVE_RETRY_COUNT    ( 5U )
 #endif
 
 /**
@@ -119,8 +119,8 @@
  * <b>Default value:</b> `5000`
  */
 #ifndef MQTT_PINGRESP_TIMEOUT_MS
-    /* Wait 5 seconds by default for a ping response. */
-    #define MQTT_PINGRESP_TIMEOUT_MS    ( 5000U )
+/* Wait 5 seconds by default for a ping response. */
+#define MQTT_PINGRESP_TIMEOUT_MS    ( 5000U )
 #endif
 
 /**
@@ -129,24 +129,24 @@
  *
  * @note If this value is less than the keep alive interval than
  * it will be used instead.
- * 
+ *
  * <b>Possible values:</b> Any positive integer up to SIZE_MAX. <br>
  * <b>Default value:</b> '30000'
-*/
+ */
 #ifndef PACKET_TX_TIMEOUT_MS
-    #define PACKET_TX_TIMEOUT_MS    ( 30000U )
+#define PACKET_TX_TIMEOUT_MS    ( 30000U )
 #endif
 
 /**
  * @brief Maximum number of milliseconds of RX inactivity to wait
  * before initiating a PINGREQ
- * 
+ *
  * <b>Possible values:</b> Any positive integer up to SIZE_MAX. <br>
  * <b>Default value:</b> '30000'
  *
-*/
+ */
 #ifndef PACKET_RX_TIMEOUT_MS
-    #define PACKET_RX_TIMEOUT_MS    ( 30000U )
+#define PACKET_RX_TIMEOUT_MS    ( 30000U )
 #endif
 
 /**
@@ -171,7 +171,7 @@
  *
  */
 #ifndef MQTT_RECV_POLLING_TIMEOUT_MS
-    #define MQTT_RECV_POLLING_TIMEOUT_MS    ( 10U )
+#define MQTT_RECV_POLLING_TIMEOUT_MS    ( 10U )
 #endif
 
 /**
@@ -196,7 +196,7 @@
  *
  */
 #ifndef MQTT_SEND_RETRY_TIMEOUT_MS
-    #define MQTT_SEND_RETRY_TIMEOUT_MS    ( 10U )
+#define MQTT_SEND_RETRY_TIMEOUT_MS    ( 10U )
 #endif
 
 /* *INDENT-OFF* */

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -124,6 +124,32 @@
 #endif
 
 /**
+ * @brief Maximum number of milliseconds of TX inactivity to wait
+ * before initiating a PINGREQ
+ *
+ * @note If this value is less than the keep alive interval than
+ * it will be used instead.
+ * 
+ * <b>Possible values:</b> Any positive integer up to SIZE_MAX. <br>
+ * <b>Default value:</b> '30000'
+*/
+#ifndef PACKET_TX_TIMEOUT_MS
+    #define PACKET_TX_TIMEOUT_MS    ( 30000U )
+#endif
+
+/**
+ * @brief Maximum number of milliseconds of RX inactivity to wait
+ * before initiating a PINGREQ
+ * 
+ * <b>Possible values:</b> Any positive integer up to SIZE_MAX. <br>
+ * <b>Default value:</b> '30000'
+ *
+*/
+#ifndef PACKET_RX_TIMEOUT_MS
+    #define PACKET_RX_TIMEOUT_MS    ( 30000U )
+#endif
+
+/**
  * @brief The maximum duration between non-empty network reads while
  * receiving an MQTT packet via the #MQTT_ProcessLoop or #MQTT_ReceiveLoop
  * API functions.

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1985,7 +1985,6 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     TransportInterface_t transport;
     MQTTFixedBuffer_t networkBuffer;
     ProcessLoopReturns_t expectParams;
-    size_t pingreqSize = MQTT_PACKET_PINGREQ_SIZE;
 
     setupTransportInterface( &transport );
 

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -491,7 +491,7 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
     {
         if( ( pContext->waitingForPingResp == false ) &&
             ( pContext->keepAliveIntervalSec != 0U ) &&
-            ( ( globalEntryTime - pContext->lastPacketTime ) > ( 1000U * pContext->keepAliveIntervalSec ) ) )
+            ( ( globalEntryTime - pContext->lastPacketTxTime ) > ( 1000U * pContext->keepAliveIntervalSec ) ) )
         {
             MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
             /* Replace pointer parameter being passed to the method. */
@@ -1934,7 +1934,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
-    context.lastPacketTime = getTime();
+    context.lastPacketTxTime = getTime();
     /* Set expected return values in the loop. All success. */
     resetProcessLoopParams( &expectParams );
     expectProcessLoopCalls( &context, &expectParams );
@@ -1944,7 +1944,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = true;
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
-    context.lastPacketTime = MQTT_ONE_SECOND_TO_MS;
+    context.lastPacketTxTime = MQTT_ONE_SECOND_TO_MS;
     context.pingReqSendTimeMs = MQTT_ONE_SECOND_TO_MS;
     /* Set expected return values in the loop. All success. */
     resetProcessLoopParams( &expectParams );
@@ -1955,7 +1955,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Happy_Paths( void )
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.waitingForPingResp = false;
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
-    context.lastPacketTime = 0;
+    context.lastPacketTxTime = 0;
     /* Set expected return values in the loop. All success. */
     resetProcessLoopParams( &expectParams );
     expectProcessLoopCalls( &context, &expectParams );
@@ -1983,7 +1983,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
-    context.lastPacketTime = 0;
+    context.lastPacketTxTime = 0;
     context.pingReqSendTimeMs = 0;
     context.waitingForPingResp = true;
     /* Set expected return values in the loop. */
@@ -2391,7 +2391,7 @@ void test_MQTT_Ping_happy_path( void )
     mqttStatus = MQTT_Ping( &context );
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 
-    TEST_ASSERT_EQUAL( context.lastPacketTime, context.pingReqSendTimeMs );
+    TEST_ASSERT_EQUAL( context.lastPacketTxTime, context.pingReqSendTimeMs );
     TEST_ASSERT_TRUE( context.waitingForPingResp );
 }
 

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1999,7 +1999,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     context.waitingForPingResp = false;
     /* Set expected return values in the loop. */
     resetProcessLoopParams( &expectParams );
-    expectParams.processLoopStatus = MQTTKeepAliveTimeout;
+    expectParams.processLoopStatus = MQTTSuccess;
     expectProcessLoopCalls( &context, &expectParams );
 }
 

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1991,7 +1991,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     expectParams.processLoopStatus = MQTTKeepAliveTimeout;
     expectProcessLoopCalls( &context, &expectParams );
 
-    context.keepAliveIntervalSec = PACKET_RX_TIMEOUT_MS + 5;
+    context.keepAliveIntervalSec = PACKET_TX_TIMEOUT_MS + 5;
     context.lastPacketTxTime = 0;
     context.pingReqSendTimeMs = 0;
     context.waitingForPingResp = true;

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1991,7 +1991,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     expectParams.processLoopStatus = MQTTKeepAliveTimeout;
     expectProcessLoopCalls( &context, &expectParams );
 
-    context.keepAliveIntervalSec = PACKET_TX_TIMEOUT_MS + 5;
+    context.keepAliveIntervalSec = 35;
     context.lastPacketTxTime = 0;
     context.pingReqSendTimeMs = 0;
     context.waitingForPingResp = true;

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1984,6 +1984,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
     context.lastPacketTxTime = 0;
+    context.lastPacketRxTime = 0;
     context.pingReqSendTimeMs = 0;
     context.waitingForPingResp = true;
     /* Set expected return values in the loop. */
@@ -1993,8 +1994,9 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
 
     context.keepAliveIntervalSec = 35;
     context.lastPacketTxTime = 0;
+    context.lastPacketRxTime = 0;
     context.pingReqSendTimeMs = 0;
-    context.waitingForPingResp = true;
+    context.waitingForPingResp = false;
     /* Set expected return values in the loop. */
     resetProcessLoopParams( &expectParams );
     expectParams.processLoopStatus = MQTTKeepAliveTimeout;

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -100,11 +100,11 @@
  * that the API can support normal behavior even if the timer
  * overflows.
  *
- * @note Currently, there are 5 calls within a single iteration.
+ * @note Currently, there are 6 calls within a single iteration.
  * This can change when the implementation changes which would be
  * caught through unit test failure.
  */
-#define MQTT_TIMER_CALLS_PER_ITERATION         ( 5 )
+#define MQTT_TIMER_CALLS_PER_ITERATION         ( 6 )
 
 /**
  * @brief Timeout for the timer overflow test.

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -1990,6 +1990,15 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths( void )
     resetProcessLoopParams( &expectParams );
     expectParams.processLoopStatus = MQTTKeepAliveTimeout;
     expectProcessLoopCalls( &context, &expectParams );
+
+    context.keepAliveIntervalSec = PACKET_RX_TIMEOUT_MS + 5;
+    context.lastPacketTxTime = 0;
+    context.pingReqSendTimeMs = 0;
+    context.waitingForPingResp = true;
+    /* Set expected return values in the loop. */
+    resetProcessLoopParams( &expectParams );
+    expectParams.processLoopStatus = MQTTKeepAliveTimeout;
+    expectProcessLoopCalls( &context, &expectParams );
 }
 
 /**


### PR DESCRIPTION
Extend the PINGREQ logic to send a PINGREQ not only when the client has not generated any outgoing message for the Keep Alive period (ref: [3.1.2.10 Keep Alive](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349238) (http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349238)). But to also generate a PINGREQ if we have not received any incoming message for the Keep Alive period, then in the case that we are continuously retransmitting a PUBLISH qos1 but receiving no ACK, we will still generate a PINGREQ after the specified Keep Alive delay. The spec explicitly allows a PINGREQ to be sent at any time and so this change in behavior maintains compliance.

Additional configuration options have been added (via the header file). This allows for the specification of different timeouts on idle transmit (TX) vs receive (RX) activity.

The smaller of the runtime configuration keepAliveTimeout and compile time transmit (TX) time timeout are used as the transmit timeout.