### PR TITLE
Send keep alive messages when Rx path is idle

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td><center>3.0K</center></td>
+        <td><center>3.1K</center></td>
         <td><center>2.6K</center></td>
     </tr>
     <tr>
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>6.9K</center></b></td>
+        <td><b><center>7.0K</center></b></td>
         <td><b><center>5.7K</center></b></td>
     </tr>
 </table>

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -119,6 +119,7 @@ keepaliveintervalsec
 keepalivems
 keepaliveseconds
 lastpackettime
+lastreceivedpackettime
 linux
 logdebug
 logerror
@@ -318,6 +319,7 @@ resending
 reservestate
 responsecode
 rm
+rx
 sdk
 searchstates
 sendpacket

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -123,7 +123,7 @@ static MQTTStatus_t discardPacket( const MQTTContext_t * pContext,
  *
  * @return #MQTTSuccess or #MQTTRecvFailed.
  */
-static MQTTStatus_t receivePacket( const MQTTContext_t * pContext,
+static MQTTStatus_t receivePacket( MQTTContext_t * pContext,
                                    MQTTPacketInfo_t incomingPacket,
                                    uint32_t remainingTimeMs );
 
@@ -261,7 +261,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
  * ##MQTTRecvFailed if transport recv failed;
  * #MQTTSuccess otherwise.
  */
-static MQTTStatus_t receiveConnack( const MQTTContext_t * pContext,
+static MQTTStatus_t receiveConnack( MQTTContext_t * pContext,
                                     uint32_t timeoutMs,
                                     bool cleanSession,
                                     MQTTPacketInfo_t * pIncomingPacket,
@@ -853,7 +853,7 @@ static MQTTStatus_t discardPacket( const MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t receivePacket( const MQTTContext_t * pContext,
+static MQTTStatus_t receivePacket( MQTTContext_t * pContext,
                                    MQTTPacketInfo_t incomingPacket,
                                    uint32_t remainingTimeMs )
 {
@@ -1463,7 +1463,7 @@ static MQTTStatus_t sendPublish( MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t receiveConnack( const MQTTContext_t * pContext,
+static MQTTStatus_t receiveConnack( MQTTContext_t * pContext,
                                     uint32_t timeoutMs,
                                     bool cleanSession,
                                     MQTTPacketInfo_t * pIncomingPacket,

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -882,7 +882,10 @@ static MQTTStatus_t receivePacket( const MQTTContext_t * pContext,
 
         if( bytesReceived == ( int32_t ) bytesToReceive )
         {
-            /* Receive successful, bytesReceived == bytesToReceive. */
+            /* Receive successful, bytesReceived == bytesToReceive. Record
+             * the time of last successful receive. */
+            pContext->lastReceivedPacketTime = pContext->getTime();
+
             LogDebug( ( "Packet received. ReceivedBytes=%ld.",
                         ( long int ) bytesReceived ) );
         }
@@ -1024,7 +1027,8 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
         }
         else
         {
-            if( calculateElapsedTime( now, pContext->lastPacketTime ) > keepAliveMs )
+            if( ( calculateElapsedTime( now, pContext->lastPacketTime ) > keepAliveMs ) ||
+                ( calculateElapsedTime( now, pContext->lastReceivedPacketTime ) > keepAliveMs ) )
             {
                 status = MQTT_Ping( pContext );
             }

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -213,6 +213,11 @@ typedef struct MQTTContext
     uint32_t lastPacketTime;
 
     /**
+     * @brief Timestamp of the last packet received by the library.
+     */
+    uint32_t lastReceivedPacketTime;
+
+    /**
      * @brief Whether the library sent a packet during a call of #MQTT_ProcessLoop or
      * #MQTT_ReceiveLoop.
      */
@@ -720,7 +725,8 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext,
  *      {
  *          // Since this function does not send pings, the application may need
  *          // to in order to comply with keep alive.
- *          if( ( pContext->getTime() - pContext->lastPacketTime ) > keepAliveMs )
+ *          if( ( pContext->getTime() - pContext->lastPacketTime ) > keepAliveMs ) ||
+ *              ( pContext->getTime() - pContext->lastReceivedPacketTime ) > keepAliveMs ) )
  *          {
  *              status = MQTT_Ping( pContext );
  *          }

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -491,8 +491,8 @@ static void expectProcessLoopCalls( MQTTContext_t * const pContext,
     {
         if( ( pContext->waitingForPingResp == false ) &&
             ( pContext->keepAliveIntervalSec != 0U ) &&
-            ( ( globalEntryTime - pContext->lastPacketTime ) > ( 1000U * pContext->keepAliveIntervalSec ) ||
-              ( globalEntryTime - pContext->lastReceivedPacketTime ) > ( 1000U * pContext->keepAliveIntervalSec ) ) )
+            ( ( ( globalEntryTime - pContext->lastPacketTime ) > ( 1000U * pContext->keepAliveIntervalSec ) ) ||
+              ( ( globalEntryTime - pContext->lastReceivedPacketTime ) > ( 1000U * pContext->keepAliveIntervalSec ) ) ) )
         {
             MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
             /* Replace pointer parameter being passed to the method. */
@@ -1985,6 +1985,7 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Tx_Idle( void )
 
     /* Tx path is idle and therefore, PINGREQ should be sent. */
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
+
     /* Since the clock started at 1000, all the calls to getTime() will return
      * numbers greater than 1000. Setting lastPacketTime to 0, therefore, ensures
      * that Tx path is determined idle for more than 1000 milliseconds which is
@@ -2026,10 +2027,11 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Rx_Idle( void )
     /* Rx path is idle and therefore PINGREQ, should be sent. */
     context.keepAliveIntervalSec = MQTT_SAMPLE_KEEPALIVE_INTERVAL_S;
     context.lastPacketTime = getTime();
-     /* Since the clock started at 1000, all the calls to getTime() will return
-      * numbers greater than 1000. Setting lastReceivedPacketTime to 0, therefore,
-      * ensures that Rx path is determined idle for more than 1000 milliseconds
-      * which is the keep alive interval. */
+
+    /* Since the clock started at 1000, all the calls to getTime() will return
+     * numbers greater than 1000. Setting lastReceivedPacketTime to 0, therefore,
+     * ensures that Rx path is determined idle for more than 1000 milliseconds
+     * which is the keep alive interval. */
     context.lastReceivedPacketTime = 0;
 
     MQTT_GetIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTNoDataAvailable );


### PR DESCRIPTION
Description
---------
Currently MQTT PINGREQ is sent when Tx path is idle. As a result, broken connections are sometimes are detected late as the TCP stack keeps buffering outgoing packets. This change updates the code to send PINGREQ when either Tx or Rx path is idle.

This was reported here - https://github.com/aws/amazon-freertos/issues/3482