### PR TITLE
Add cancel callback API

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -14,7 +14,7 @@
     </tr>
     <tr>
         <td>core_mqtt_state.c</td>
-        <td><center>1.4K</center></td>
+        <td><center>1.5K</center></td>
         <td><center>1.1K</center></td>
     </tr>
     <tr>
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>7.0K</center></b></td>
+        <td><b><center>7.1K</center></b></td>
         <td><b><center>5.8K</center></b></td>
     </tr>
 </table>

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1768,8 +1768,8 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
-MQTTStatus_t MQTT_CancelPublish( MQTTContext_t * pContext,
-                                 uint16_t packetId )
+MQTTStatus_t MQTT_CancelCallback( MQTTContext_t * pContext,
+                                  uint16_t packetId )
 {
     MQTTStatus_t status;
 

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1768,6 +1768,19 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
+MQTTStatus_t MQTT_CancelPublish( MQTTContext_t * pContext,
+                                 uint16_t packetId )
+{
+    MQTTStatus_t status;
+
+    status = MQTT_RemoveStateRecord( pContext,
+                                     packetId );
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
 MQTTStatus_t MQTT_Connect( MQTTContext_t * pContext,
                            const MQTTConnectInfo_t * pConnectInfo,
                            const MQTTPublishInfo_t * pWillInfo,

--- a/source/core_mqtt_state.c
+++ b/source/core_mqtt_state.c
@@ -956,6 +956,7 @@ MQTTStatus_t MQTT_RemoveStateRecord( MQTTContext_t * pMqttContext,
     }
     else
     {
+        /* Delete the record. */
         updateRecord( records,
                       recordIndex,
                       MQTTStateNull,

--- a/source/core_mqtt_state.c
+++ b/source/core_mqtt_state.c
@@ -926,6 +926,47 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
 
 /*-----------------------------------------------------------*/
 
+MQTTStatus_t MQTT_RemoveStateRecord( MQTTContext_t * pMqttContext,
+                                     uint16_t packetId )
+{
+    MQTTStatus_t status = MQTTSuccess;
+    MQTTPubAckInfo_t* records = NULL;
+    size_t recordIndex = MQTT_STATE_ARRAY_MAX_COUNT;
+    MQTTQoS_t qos = MQTTQoS0;
+    MQTTPublishState_t currentState = MQTTStateNull;
+
+    assert( pMqttContext != NULL );
+    assert( pMqttContext->outgoingPublishRecords != NULL );
+
+    records = pMqttContext->outgoingPublishRecords;
+
+    recordIndex = findInRecord( records,
+                                MQTT_STATE_ARRAY_MAX_COUNT,
+                                packetId,
+                                &qos,
+                                &currentState );
+
+    if( currentState == MQTTStateNull )
+    {
+        status = MQTTBadParameter;
+    }
+    else if( ( qos != MQTTQoS1 ) && ( qos != MQTTQoS2 ) )
+    {
+        status = MQTTBadParameter;
+    }
+    else
+    {
+        updateRecord( records,
+                      recordIndex,
+                      MQTTStateNull,
+                      true );
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
 MQTTStatus_t MQTT_UpdateStateAck( MQTTContext_t * pMqttContext,
                                   uint16_t packetId,
                                   MQTTPubAckType_t packetType,

--- a/source/core_mqtt_state.c
+++ b/source/core_mqtt_state.c
@@ -930,7 +930,7 @@ MQTTStatus_t MQTT_RemoveStateRecord( MQTTContext_t * pMqttContext,
                                      uint16_t packetId )
 {
     MQTTStatus_t status = MQTTSuccess;
-    MQTTPubAckInfo_t* records = NULL;
+    MQTTPubAckInfo_t * records = NULL;
     size_t recordIndex = MQTT_STATE_ARRAY_MAX_COUNT;
     MQTTQoS_t qos = MQTTQoS0;
     MQTTPublishState_t currentState = MQTTStateNull;

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -528,7 +528,7 @@ MQTTStatus_t MQTT_Publish( MQTTContext_t * pContext,
 /* @[declare_mqtt_publish] */
 
 /**
- * @brief Cancels an outgoing publish waiting for an ACK by the broker by
+ * @brief Cancels an outgoing publish callback (only for QoS > QoS0) by
  * removing it from the pending ACK list.
  *
  * @param[in] pContext Initialized MQTT context.
@@ -537,10 +537,10 @@ MQTTStatus_t MQTT_Publish( MQTTContext_t * pContext,
  * @return #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
- /* @[declare_mqtt_cancelpublish] */
-MQTTStatus_t MQTT_CancelPublish( MQTTContext_t * pContext,
-                                 uint16_t packetId );
-/* @[declare_mqtt_cancelpublish] */
+ /* @[declare_mqtt_cancelcallback] */
+MQTTStatus_t MQTT_CancelCallback( MQTTContext_t * pContext,
+                                  uint16_t packetId );
+/* @[declare_mqtt_cancelcallback] */
 
 /**
  * @brief Sends an MQTT PINGREQ to broker.

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -537,7 +537,7 @@ MQTTStatus_t MQTT_Publish( MQTTContext_t * pContext,
  * @return #MQTTBadParameter if invalid parameters are passed;
  * #MQTTSuccess otherwise.
  */
- /* @[declare_mqtt_cancelcallback] */
+/* @[declare_mqtt_cancelcallback] */
 MQTTStatus_t MQTT_CancelCallback( MQTTContext_t * pContext,
                                   uint16_t packetId );
 /* @[declare_mqtt_cancelcallback] */

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -528,6 +528,21 @@ MQTTStatus_t MQTT_Publish( MQTTContext_t * pContext,
 /* @[declare_mqtt_publish] */
 
 /**
+ * @brief Cancels an outgoing publish waiting for an ACK by the broker by
+ * removing it from the pending ACK list.
+ *
+ * @param[in] pContext Initialized MQTT context.
+ * @param[in] packetId packet ID corresponding to the outstanding publish.
+ *
+ * @return #MQTTBadParameter if invalid parameters are passed;
+ * #MQTTSuccess otherwise.
+ */
+ /* @[declare_mqtt_cancelpublish] */
+MQTTStatus_t MQTT_CancelPublish( MQTTContext_t * pContext,
+                                 uint16_t packetId );
+/* @[declare_mqtt_cancelpublish] */
+
+/**
  * @brief Sends an MQTT PINGREQ to broker.
  *
  * @param[in] pContext Initialized and connected MQTT context.

--- a/source/include/core_mqtt_state.h
+++ b/source/include/core_mqtt_state.h
@@ -125,6 +125,24 @@ MQTTStatus_t MQTT_UpdateStatePublish( MQTTContext_t * pMqttContext,
 /** @endcond */
 
 /**
+ * @fn MQTTStatus_t MQTT_RemoveStateRecord( MQTTContext_t * pMqttContext, uint16_t packetId );
+ * @brief Remove the state record for a PUBLISH packet.
+ *
+ * @param[in] pMqttContext Initialized MQTT context.
+ * @param[in] packetId ID of the PUBLISH packet.
+ *
+ * @return #MQTTBadParameter or #MQTTSuccess.
+ */
+
+/**
+ * @cond DOXYGEN_IGNORE
+ * Doxygen should ignore this definition, this function is private.
+ */
+MQTTStatus_t MQTT_RemoveStateRecord( MQTTContext_t * pMqttContext,
+                                     uint16_t packetId );
+/** @endcond */
+
+/**
  * @fn MQTTPublishState_t MQTT_CalculateStateAck( MQTTPubAckType_t packetType, MQTTStateOperation_t opType, MQTTQoS_t qos );
  * @brief Calculate the state from a PUBACK, PUBREC, PUBREL, or PUBCOMP.
  *


### PR DESCRIPTION
This PR adds a MQTT_CancelCallback command to cancel a callback for any outgoing publish (QoS > QoS0).
This would enable the user to:
- Cancel any publish command thereby enabling them to free/reuse the memory which is consumed by the topic string and the payload.
- Delete any task by `free`ing the memory associated with a publish without worrying about repercussions.