### PR TITLE
Update MQTT logging so that log levels of the library do not leak

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -29,6 +29,12 @@
 
 #include "core_mqtt.h"
 #include "core_mqtt_state.h"
+
+#define LIBRARY_LOG_NAME "MQTT"
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL MQTT_LOG_LEVEL
+#endif
+
 #include "core_mqtt_default_logging.h"
 
 /*-----------------------------------------------------------*/

--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -28,6 +28,12 @@
 #include <assert.h>
 
 #include "core_mqtt_serializer.h"
+
+#define LIBRARY_LOG_NAME "MQTT"
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL MQTT_LOG_LEVEL
+#endif
+
 #include "core_mqtt_default_logging.h"
 
 /**

--- a/source/core_mqtt_state.c
+++ b/source/core_mqtt_state.c
@@ -27,6 +27,12 @@
 #include <assert.h>
 #include <string.h>
 #include "core_mqtt_state.h"
+
+#define LIBRARY_LOG_NAME "MQTT"
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL MQTT_LOG_LEVEL
+#endif
+
 #include "core_mqtt_default_logging.h"
 
 /*-----------------------------------------------------------*/

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -41,6 +41,15 @@
 #endif
 /* *INDENT-ON* */
 
+#include "logging_levels.h"
+
+/**
+ * @brief The macro defining the default logging level.
+ */
+#ifndef MQTT_LOG_LEVEL
+    #define MQTT_LOG_LEVEL LOG_ERROR
+#endif
+
 /* The macro definition for MQTT_DO_NOT_USE_CUSTOM_CONFIG is for Doxygen
  * documentation only. */
 


### PR DESCRIPTION
This PR defines the MQTT library log levels. They are defined as such that they do not leak into other libraries/applications which include core_mqtt.h

It is done in this way so that the API doesn't have to change.

Background: The core_mqtt.h header declares the `MQTTContext_t` structure which has configurable number of unacknowledged packets. This configuration comes from `core_mqtt_config.h`. This config file, however, also defines the logging levels. Thus, any library/application which includes `core_mqtt.h` (thereby including `core_mqtt_config.h`) gets the definitions of the logging macros. This is the leak that this PR aims to plug.

There were a few options that were considered:
- Asking the user for the memory for the unACKed packet list while calling MQTT_InIt. However, that might confuse the users and complicate the API
- Moving the logging macros to a private header which is included by the source files. This approach was discarded since this means that any user wanting to modify the logging level will need to modify with a private header file of the code base. This did not seem right at the time.