### PR TITLE
Modify a check to make sure that keep alive is sent even when data is in the buffer

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1695,6 +1695,11 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
                 /* Reset the status. */
                 status = statusCopy;
             }
+            else
+            {
+                LogError( ( "Handling of keep alive failed. Status=%s",
+                            MQTT_Status_strerror( status ) ) );
+            }
         }
     }
 
@@ -1707,7 +1712,7 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
     /* Any other error code. */
     else if( status != MQTTSuccess )
     {
-        LogError( ( "Receiving incoming packet length failed. Status=%s",
+        LogError( ( "Call to receiveSingleIteration failed. Status=%s",
                     MQTT_Status_strerror( status ) ) );
     }
     /* If the MQTT Packet size is bigger than the buffer itself. */

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1663,7 +1663,6 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
          * the buffer. */
         status = MQTTNoDataAvailable;
     }
-
     /* Either something was received, or there is still data to be processed in the
      * buffer, or both. */
     else
@@ -1678,22 +1677,33 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
         totalMQTTPacketLength = incomingPacket.remainingLength + incomingPacket.headerLength;
     }
 
+    /* No data was received, check for keep alive timeout. */
     if( recvBytes == 0 )
     {
         if( manageKeepAlive == true )
         {
+            /* Keep the copy of the status to be reset later. */
+            MQTTStatus_t statusCopy = status;
+
             /* Assign status so an error can be bubbled up to application,
              * but reset it on success. */
             status = handleKeepAlive( pContext );
-        }
 
-        if( status == MQTTSuccess )
-        {
-            /* Reset the status to indicate that nothing was read
-             * from the transport interface. */
-            status = MQTTNoDataAvailable;
+            if( status == MQTTSuccess )
+            {
+                /* Reset the status. */
+                status = statusCopy;
+            }
         }
     }
+
+    /* Check whether there is data available before processing the packet further. */
+    if( ( status == MQTTNeedMoreBytes ) || ( status == MQTTNoDataAvailable ) )
+    {
+        /* Do nothing as there is nothing to be processed right now. The proper
+         * error code will be bubbled up to the user. */
+    }
+    /* Any other error code. */
     else if( status != MQTTSuccess )
     {
         LogError( ( "Receiving incoming packet length failed. Status=%s",
@@ -1702,7 +1712,8 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
     /* If the MQTT Packet size is bigger than the buffer itself. */
     else if( totalMQTTPacketLength > pContext->networkBuffer.size )
     {
-        /* Discard the packet from the buffer and from the socket buffer. */
+        /* Discard the packet from the receive buffer and drain the pending
+         * data from the socket buffer. */
         status = discardStoredPacket( pContext,
                                       &incomingPacket );
     }

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1663,6 +1663,7 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
          * the buffer. */
         status = MQTTNoDataAvailable;
     }
+
     /* Either something was received, or there is still data to be processed in the
      * buffer, or both. */
     else

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1678,7 +1678,7 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
         totalMQTTPacketLength = incomingPacket.remainingLength + incomingPacket.headerLength;
     }
 
-    if( status == MQTTNoDataAvailable )
+    if( recvBytes == 0 )
     {
         if( manageKeepAlive == true )
         {

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -3980,9 +3980,6 @@ void test_MQTT_ProcessLoop_handleKeepAlive_Error_Paths5( void )
     MQTT_ProcessIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTNeedMoreBytes );
     MQTT_ProcessIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
 
-    MQTT_GetPingreqPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_SerializePingreq_ExpectAnyArgsAndReturn( MQTTSuccess );
-
     mqttStatus = MQTT_ProcessLoop( &context );
     TEST_ASSERT_EQUAL( MQTTNeedMoreBytes, mqttStatus );
 }


### PR DESCRIPTION
The coreMQTT library is responsible for sending the keep alive messages to the broker when there is no transaction of data between the broker and the client.

The check ( `if( status == MQTTNoDataAvailable )` ) for that condition is not correct anymore (since PR https://github.com/FreeRTOS/coreMQTT/pull/218) because this condition is only set when there is no data in the socket AND none in the receive buffer. Thus, if there is any data in the receive buffer, it would prevent the library from sending a ping.

But for the matter of keep alive, the server does not care whether there is data in the buffer or not. It only cares when was the last TCP transaction with the client which can be depicted by the data in the socket.

This PR updates the `if` condition such that the sending of keep alive is only based on the reception of data or lack thereof from the socket. The change is as follows:
```
-   if( status == MQTTNoDataAvailable ) // This status value is set only when there is no data in the buffer and not in the socket.
+   if( recvBytes == 0 ) // This value shows that no more data is available in the socket.
```