### PR TITLE
Add SPDX identifier to source files

### DIFF
--- a/lexicon.txt
+++ b/lexicon.txt
@@ -148,6 +148,7 @@ mib
 min
 minimise
 misra
+mit
 modifyincomingpacket
 mq
 mqtt
@@ -370,6 +371,7 @@ somepassword
 sometransportcontext
 someusername
 sourcelength
+spdx
 src
 stateafterdeserialize
 stateafterserialize

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/core_mqtt_state.c
+++ b/source/core_mqtt_state.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/include/core_mqtt_config_defaults.h
+++ b/source/include/core_mqtt_config_defaults.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/include/core_mqtt_default_logging.h
+++ b/source/include/core_mqtt_default_logging.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/include/core_mqtt_serializer.h
+++ b/source/include/core_mqtt_serializer.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/include/core_mqtt_state.h
+++ b/source/include/core_mqtt_state.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/include/core_mqtt_config.h
+++ b/test/cbmc/include/core_mqtt_config.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/include/event_callback_stub.h
+++ b/test/cbmc/include/event_callback_stub.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/include/get_time_stub.h
+++ b/test/cbmc/include/get_time_stub.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/include/mqtt_cbmc_state.h
+++ b/test/cbmc/include/mqtt_cbmc_state.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/include/network_interface_stubs.h
+++ b/test/cbmc/include/network_interface_stubs.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_Connect/MQTT_Connect_harness.c
+++ b/test/cbmc/proofs/MQTT_Connect/MQTT_Connect_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_DeserializeAck/MQTT_DeserializeAck_harness.c
+++ b/test/cbmc/proofs/MQTT_DeserializeAck/MQTT_DeserializeAck_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_DeserializePublish/MQTT_DeserializePublish_harness.c
+++ b/test/cbmc/proofs/MQTT_DeserializePublish/MQTT_DeserializePublish_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_Disconnect/MQTT_Disconnect_harness.c
+++ b/test/cbmc/proofs/MQTT_Disconnect/MQTT_Disconnect_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_GetIncomingPacketTypeAndLength/MQTT_GetIncomingPacketTypeAndLength_harness.c
+++ b/test/cbmc/proofs/MQTT_GetIncomingPacketTypeAndLength/MQTT_GetIncomingPacketTypeAndLength_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_GetPacketId/MQTT_GetPacketId_harness.c
+++ b/test/cbmc/proofs/MQTT_GetPacketId/MQTT_GetPacketId_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_GetSubAckStatusCodes/MQTT_GetSubAckStatusCodes_harness.c
+++ b/test/cbmc/proofs/MQTT_GetSubAckStatusCodes/MQTT_GetSubAckStatusCodes_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_Init/MQTT_Init_harness.c
+++ b/test/cbmc/proofs/MQTT_Init/MQTT_Init_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_MatchTopic/MQTT_MatchTopic_harness.c
+++ b/test/cbmc/proofs/MQTT_MatchTopic/MQTT_MatchTopic_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_Ping/MQTT_Ping_harness.c
+++ b/test/cbmc/proofs/MQTT_Ping/MQTT_Ping_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_ProcessLoop/MQTT_ProcessLoop_harness.c
+++ b/test/cbmc/proofs/MQTT_ProcessLoop/MQTT_ProcessLoop_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_Publish/MQTT_Publish_harness.c
+++ b/test/cbmc/proofs/MQTT_Publish/MQTT_Publish_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_ReceiveLoop/MQTT_ReceiveLoop_harness.c
+++ b/test/cbmc/proofs/MQTT_ReceiveLoop/MQTT_ReceiveLoop_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializeAck/MQTT_SerializeAck_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializeAck/MQTT_SerializeAck_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializeConnect/MQTT_SerializeConnect_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializeConnect/MQTT_SerializeConnect_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializeDisconnect/MQTT_SerializeDisconnect_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializeDisconnect/MQTT_SerializeDisconnect_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializePingreq/MQTT_SerializePingreq_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializePingreq/MQTT_SerializePingreq_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializePublish/MQTT_SerializePublish_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializePublish/MQTT_SerializePublish_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializePublishHeader/MQTT_SerializePublishHeader_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializePublishHeader/MQTT_SerializePublishHeader_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializeSubscribe/MQTT_SerializeSubscribe_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializeSubscribe/MQTT_SerializeSubscribe_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_SerializeUnsubscribe/MQTT_SerializeUnsubscribe_harness.c
+++ b/test/cbmc/proofs/MQTT_SerializeUnsubscribe/MQTT_SerializeUnsubscribe_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_Subscribe/MQTT_Subscribe_harness.c
+++ b/test/cbmc/proofs/MQTT_Subscribe/MQTT_Subscribe_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/proofs/MQTT_Unsubscribe/MQTT_Unsubscribe_harness.c
+++ b/test/cbmc/proofs/MQTT_Unsubscribe/MQTT_Unsubscribe_harness.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/sources/mqtt_cbmc_state.c
+++ b/test/cbmc/sources/mqtt_cbmc_state.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/stubs/event_callback_stub.c
+++ b/test/cbmc/stubs/event_callback_stub.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/stubs/get_time_stub.c
+++ b/test/cbmc/stubs/get_time_stub.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/cbmc/stubs/memmove.c
+++ b/test/cbmc/stubs/memmove.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 
 void * memmove( void * destination,
+ *
+ * SPDX-License-Identifier: MIT
                 const void * source,
                 size_t num )
 {

--- a/test/cbmc/stubs/memmove.c
+++ b/test/cbmc/stubs/memmove.c
@@ -1,8 +1,30 @@
-#include <stdlib.h>
-
-void * memmove( void * destination,
+/*
+ * coreMQTT v2.0.0
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+ 
+ #include <stdlib.h>
+
+void * memmove( void * destination,
                 const void * source,
                 size_t num )
 {

--- a/test/cbmc/stubs/memmove.c
+++ b/test/cbmc/stubs/memmove.c
@@ -21,8 +21,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
- 
- #include <stdlib.h>
+
+#include <stdlib.h>
 
 void * memmove( void * destination,
                 const void * source,

--- a/test/cbmc/stubs/network_interface_stubs.c
+++ b/test/cbmc/stubs/network_interface_stubs.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/unit-test/core_mqtt_config.h
+++ b/test/unit-test/core_mqtt_config.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/unit-test/core_mqtt_serializer_utest.c
+++ b/test/unit-test/core_mqtt_serializer_utest.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/unit-test/core_mqtt_state_utest.c
+++ b/test/unit-test/core_mqtt_state_utest.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/unit-test/logging/logging_levels.h
+++ b/test/unit-test/logging/logging_levels.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to

--- a/test/unit-test/logging/logging_stack.h
+++ b/test/unit-test/logging/logging_stack.h
@@ -2,6 +2,8 @@
  * coreMQTT v2.0.0
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
+ * SPDX-License-Identifier: MIT
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to


### PR DESCRIPTION
This PR adds the SPDX identifier (MIT) to all source and header files of the repository.