### PR TITLE
Fixed multiple Sub/Unsub request sending logic

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -9,7 +9,7 @@
     </tr>
     <tr>
         <td>core_mqtt.c</td>
-        <td><center>4.0K</center></td>
+        <td><center>4.1K</center></td>
         <td><center>3.4K</center></td>
     </tr>
     <tr>
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>8.5K</center></b></td>
+        <td><b><center>8.6K</center></b></td>
         <td><b><center>6.9K</center></b></td>
     </tr>
 </table>

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1940,9 +1940,9 @@ static MQTTStatus_t sendSubscribeWithoutCopy( MQTTContext_t * pContext,
             /* Increment the pointer. */
             pIterator++;
 
-            /* Two slots get used by the topic string length and topic string. And
-             * one slot gets used by the quality of service. */
-            ioVectorLength += subscriptionStringVectorSlots;
+            /* Two slots get used by the topic string length and topic string.
+             * One slot gets used by the quality of service. */
+            ioVectorLength += vectorsAdded + 1U;
 
             subscriptionsSent++;
 
@@ -1986,13 +1986,13 @@ static MQTTStatus_t sendUnsubscribeWithoutCopy( MQTTContext_t * pContext,
     size_t unsubscriptionsSent = 0U;
     size_t ioVectorLength = 0U;
     /* For unsubscribe, only two vector slots are required per topic string. */
-    const size_t subscriptionStringVectorSlots = 2U;
+    const size_t unsubscribeStringVectorSlots = 2U;
     size_t vectorsAdded;
     size_t topicFieldLengthIndex;
 
     /* The vector array should be at least three element long as the topic
      * string needs these many vector elements to be stored. */
-    assert( MQTT_SUB_UNSUB_MAX_VECTORS >= subscriptionStringVectorSlots );
+    assert( MQTT_SUB_UNSUB_MAX_VECTORS >= unsubscribeStringVectorSlots );
 
     pIndex = unsubscribeheader;
     pIterator = pIoVector;
@@ -2018,7 +2018,7 @@ static MQTTStatus_t sendUnsubscribeWithoutCopy( MQTTContext_t * pContext,
         topicFieldLengthIndex = 0;
 
         /* Check whether the subscription topic will fit in the given vector. */
-        while( ( ioVectorLength <= ( MQTT_SUB_UNSUB_MAX_VECTORS - subscriptionStringVectorSlots ) ) &&
+        while( ( ioVectorLength <= ( MQTT_SUB_UNSUB_MAX_VECTORS - unsubscribeStringVectorSlots ) ) &&
                ( unsubscriptionsSent < subscriptionCount ) )
         {
             /* The topic filter gets sent next. */
@@ -2030,8 +2030,8 @@ static MQTTStatus_t sendUnsubscribeWithoutCopy( MQTTContext_t * pContext,
 
             /* Update the iterator to point to the next empty location. */
             pIterator = &pIterator[ vectorsAdded ];
-            /* Two slots get used by the topic string length and topic string. */
-            ioVectorLength += subscriptionStringVectorSlots;
+            /* Update the total count based on how many vectors were added. */
+            ioVectorLength += vectorsAdded;
 
             unsubscriptionsSent++;
 

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1881,13 +1881,14 @@ static MQTTStatus_t sendSubscribeWithoutCopy( MQTTContext_t * pContext,
     uint8_t * pIndex;
     TransportOutVector_t pIoVector[ MQTT_SUB_UNSUB_MAX_VECTORS ];
     TransportOutVector_t * pIterator;
-    uint8_t serializedTopicFieldLength[ 2 ];
+    uint8_t serializedTopicFieldLength[ MQTT_SUB_UNSUB_MAX_VECTORS ][ 2 ];
     size_t totalPacketLength = 0U;
     size_t ioVectorLength = 0U;
     size_t subscriptionsSent = 0U;
     /* For subscribe, only three vector slots are required per topic string. */
     const size_t subscriptionStringVectorSlots = 3U;
     size_t vectorsAdded;
+    size_t topicFieldLengthIndex;
 
     /* The vector array should be at least three element long as the topic
      * string needs these many vector elements to be stored. */
@@ -1913,13 +1914,16 @@ static MQTTStatus_t sendSubscribeWithoutCopy( MQTTContext_t * pContext,
 
     while( ( status == MQTTSuccess ) && ( subscriptionsSent < subscriptionCount ) )
     {
+        /* Reset the index for next iteration. */
+        topicFieldLengthIndex = 0;
+
         /* Check whether the subscription topic (with QoS) will fit in the
          * given vector. */
         while( ( ioVectorLength <= ( MQTT_SUB_UNSUB_MAX_VECTORS - subscriptionStringVectorSlots ) ) &&
                ( subscriptionsSent < subscriptionCount ) )
         {
             /* The topic filter gets sent next. */
-            vectorsAdded = addEncodedStringToVector( serializedTopicFieldLength,
+            vectorsAdded = addEncodedStringToVector( serializedTopicFieldLength[ topicFieldLengthIndex ],
                                                      pSubscriptionList[ subscriptionsSent ].pTopicFilter,
                                                      pSubscriptionList[ subscriptionsSent ].topicFilterLength,
                                                      pIterator,
@@ -1941,6 +1945,9 @@ static MQTTStatus_t sendSubscribeWithoutCopy( MQTTContext_t * pContext,
             ioVectorLength += subscriptionStringVectorSlots;
 
             subscriptionsSent++;
+
+            /* The index needs to be updated for next iteration. */
+            topicFieldLengthIndex++;
         }
 
         if( sendMessageVector( pContext,
@@ -1974,13 +1981,14 @@ static MQTTStatus_t sendUnsubscribeWithoutCopy( MQTTContext_t * pContext,
     uint8_t * pIndex;
     TransportOutVector_t pIoVector[ MQTT_SUB_UNSUB_MAX_VECTORS ];
     TransportOutVector_t * pIterator;
-    uint8_t serializedTopicFieldLength[ 2 ];
+    uint8_t serializedTopicFieldLength[ MQTT_SUB_UNSUB_MAX_VECTORS ][ 2 ];
     size_t totalPacketLength = 0U;
     size_t unsubscriptionsSent = 0U;
     size_t ioVectorLength = 0U;
     /* For unsubscribe, only two vector slots are required per topic string. */
     const size_t subscriptionStringVectorSlots = 2U;
     size_t vectorsAdded;
+    size_t topicFieldLengthIndex;
 
     /* The vector array should be at least three element long as the topic
      * string needs these many vector elements to be stored. */
@@ -2006,12 +2014,15 @@ static MQTTStatus_t sendUnsubscribeWithoutCopy( MQTTContext_t * pContext,
 
     while( ( status == MQTTSuccess ) && ( unsubscriptionsSent < subscriptionCount ) )
     {
+        /* Reset the index for next iteration. */
+        topicFieldLengthIndex = 0;
+
         /* Check whether the subscription topic will fit in the given vector. */
         while( ( ioVectorLength <= ( MQTT_SUB_UNSUB_MAX_VECTORS - subscriptionStringVectorSlots ) ) &&
                ( unsubscriptionsSent < subscriptionCount ) )
         {
             /* The topic filter gets sent next. */
-            vectorsAdded = addEncodedStringToVector( serializedTopicFieldLength,
+            vectorsAdded = addEncodedStringToVector( serializedTopicFieldLength[ topicFieldLengthIndex ],
                                                      pSubscriptionList[ unsubscriptionsSent ].pTopicFilter,
                                                      pSubscriptionList[ unsubscriptionsSent ].topicFilterLength,
                                                      pIterator,
@@ -2023,6 +2034,9 @@ static MQTTStatus_t sendUnsubscribeWithoutCopy( MQTTContext_t * pContext,
             ioVectorLength += subscriptionStringVectorSlots;
 
             unsubscriptionsSent++;
+
+            /* Update the index for next iteration. */
+            topicFieldLengthIndex++;
         }
 
         if( sendMessageVector( pContext, pIoVector, ioVectorLength ) != ( int32_t ) totalPacketLength )

--- a/test/unit-test/core_mqtt_config.h
+++ b/test/unit-test/core_mqtt_config.h
@@ -75,6 +75,6 @@ struct NetworkContext
     uint8_t ** buffer;
 };
 
-#define MQTT_SUB_UNSUB_MAX_VECTORS    ( 8U )
+#define MQTT_SUB_UNSUB_MAX_VECTORS    ( 6U )
 
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */


### PR DESCRIPTION
Whenever multiple subscribe/unsubscribe requests are sent in a single `MQTT_Subscribe`/`MQTT_Unsubscribe` API call, the topic's length is encoded before each topic according to spec: http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718063.

Currently, the topic length is encoded in a local buffer and is sent to the transport interface by reference. However, all the topic lengths get encoded in the same buffer and is sent to the transport interface. This leads to the last length being encoded and sent as the lengths of all topics.

This PR adds a fix for that. Different buffers are used for different topics before being sent to the transport interface.
It also updates the unit tests to catch such errors in the future.
