### PR TITLE
RFC: Use void* for network context pointers.

### DIFF
--- a/MigrationGuide.md
+++ b/MigrationGuide.md
@@ -143,9 +143,9 @@ void eventCallback(
      MQTTDeserializedInfo_t * pDeserializedInfo
 );
 // Network send.
-int32_t networkSend( NetworkContext_t * pContext, const void * pBuffer, size_t bytes );
+int32_t networkSend( void * pContext, const void * pBuffer, size_t bytes );
 // Network receive.
-int32_t networkRecv( NetworkContext_t * pContext, void * pBuffer, size_t bytes );
+int32_t networkRecv( void * pContext, void * pBuffer, size_t bytes );
 
 MQTTContext_t mqttContext;
 TransportInterface_t transport;
@@ -183,9 +183,9 @@ void eventCallback(
      MQTTDeserializedInfo_t * pDeserializedInfo
 );
 // Network send.
-int32_t networkSend( NetworkContext_t * pContext, const void * pBuffer, size_t bytes );
+int32_t networkSend( void * pContext, const void * pBuffer, size_t bytes );
 // Network receive.
-int32_t networkRecv( NetworkContext_t * pContext, void * pBuffer, size_t bytes );
+int32_t networkRecv( void * pContext, void * pBuffer, size_t bytes );
 
 MQTTContext_t mqttContext;
 TransportInterface_t transport;

--- a/docs/doxygen/porting.dox
+++ b/docs/doxygen/porting.dox
@@ -35,24 +35,17 @@ A port must implement functions corresponding to the following functions pointer
  - [Transport Receive](@ref TransportRecv_t): A function to receive bytes from a network.
  @code
  int32_t (* TransportRecv_t )(
-     NetworkContext_t * pNetworkContext, void * pBuffer, size_t bytesToRecv
+     void * pNetworkContext, void * pBuffer, size_t bytesToRecv
  );
  @endcode
  - [Transport Send](@ref TransportSend_t): A function to send bytes over a network.
  @code
  int32_t (* TransportSend_t )(
-     NetworkContext_t * pNetworkContext, const void * pBuffer, size_t bytesToSend
+     void * pNetworkContext, const void * pBuffer, size_t bytesToSend
  );
  @endcode
 
-The above two functions take in a pointer to a @ref NetworkContext_t, the typename of a
-`struct NetworkContext`. The NetworkContext struct must also be defined by the port, and
-ought to contain any information necessary to send and receive data with the @ref TransportSend_t
-and @ref TransportRecv_t implementations, respectively:
-@code
-struct NetworkContext {
-    // Fields necessary for the transport implementations, e.g. a TCP socket descriptor.
-};
+The above two functions take in a void pointer to an implementation-defined context.
 @endcode
 
 @section mqtt_porting_time Time Function

--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -301,7 +301,7 @@ static uint8_t * encodeString( uint8_t * pDestination,
  * @return The Remaining Length of the incoming packet.
  */
 static size_t getRemainingLength( TransportRecv_t recvFunc,
-                                  NetworkContext_t * pNetworkContext );
+                                  void * pNetworkContext );
 
 /**
  * @brief Retrieves, decodes and stores the Remaining Length from the network
@@ -799,7 +799,7 @@ static void serializePublishCommon( const MQTTPublishInfo_t * pPublishInfo,
 }
 
 static size_t getRemainingLength( TransportRecv_t recvFunc,
-                                  NetworkContext_t * pNetworkContext )
+                                  void * pNetworkContext )
 {
     size_t remainingLength = 0, multiplier = 1, bytesDecoded = 0, expectedSize = 0;
     uint8_t encodedByte = 0;
@@ -2561,7 +2561,7 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
 /*-----------------------------------------------------------*/
 
 MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( TransportRecv_t readFunc,
-                                                  NetworkContext_t * pNetworkContext,
+                                                  void * pNetworkContext,
                                                   MQTTPacketInfo_t * pIncomingPacket )
 {
     MQTTStatus_t status = MQTTSuccess;

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -186,6 +186,11 @@ typedef struct MQTTContext
     TransportInterface_t transportInterface;
 
     /**
+     * @brief The transport interface context for this MQTT connection.
+     */
+    void * pNetworkContext;
+
+    /**
      * @brief The buffer used in sending and receiving packets from the network.
      */
     MQTTFixedBuffer_t networkBuffer;
@@ -289,9 +294,9 @@ typedef struct MQTTDeserializedInfo
  *      MQTTDeserializedInfo_t * pDeserializedInfo
  * );
  * // Network send.
- * int32_t networkSend( NetworkContext_t * pContext, const void * pBuffer, size_t bytes );
+ * int32_t networkSend( void * pContext, const void * pBuffer, size_t bytes );
  * // Network receive.
- * int32_t networkRecv( NetworkContext_t * pContext, void * pBuffer, size_t bytes );
+ * int32_t networkRecv( void * pContext, void * pBuffer, size_t bytes );
  *
  * MQTTContext_t mqttContext;
  * TransportInterface_t transport;
@@ -360,9 +365,9 @@ MQTTStatus_t MQTT_Init( MQTTContext_t * pContext,
  *      MQTTDeserializedInfo_t * pDeserializedInfo
  * );
  * // Network send.
- * int32_t networkSend( NetworkContext_t * pContext, const void * pBuffer, size_t bytes );
+ * int32_t networkSend( void * pContext, const void * pBuffer, size_t bytes );
  * // Network receive.
- * int32_t networkRecv( NetworkContext_t * pContext, void * pBuffer, size_t bytes );
+ * int32_t networkRecv( void * pContext, void * pBuffer, size_t bytes );
  *
  * MQTTContext_t mqttContext;
  * TransportInterface_t transport;

--- a/source/include/core_mqtt_serializer.h
+++ b/source/include/core_mqtt_serializer.h
@@ -1046,7 +1046,7 @@ MQTTStatus_t MQTT_SerializePingreq( const MQTTFixedBuffer_t * pFixedBuffer );
  *
  * // TransportRecv_t function for reading from the network.
  * int32_t socket_recv(
- *      NetworkContext_t * pNetworkContext,
+ *      void * pNetworkContext,
  *      void * pBuffer,
  *      size_t bytesToRecv
  * );
@@ -1162,7 +1162,7 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
  *
  * // TransportRecv_t function for reading from the network.
  * int32_t socket_recv(
- *      NetworkContext_t * pNetworkContext,
+ *      void * pNetworkContext,
  *      void * pBuffer,
  *      size_t bytesToRecv
  * );
@@ -1201,7 +1201,7 @@ MQTTStatus_t MQTT_DeserializeAck( const MQTTPacketInfo_t * pIncomingPacket,
  */
 /* @[declare_mqtt_getincomingpackettypeandlength] */
 MQTTStatus_t MQTT_GetIncomingPacketTypeAndLength( TransportRecv_t readFunc,
-                                                  NetworkContext_t * pNetworkContext,
+                                                  void * pNetworkContext,
                                                   MQTTPacketInfo_t * pIncomingPacket );
 /* @[declare_mqtt_getincomingpackettypeandlength] */
 

--- a/test/cbmc/include/network_interface_stubs.h
+++ b/test/cbmc/include/network_interface_stubs.h
@@ -41,7 +41,7 @@
  *
  * @return Any value from INT32_MIN to INT32_MAX.
  */
-int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
+int32_t NetworkInterfaceReceiveStub( void * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRecv );
 
@@ -54,7 +54,7 @@ int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
  *
  * @return Any value from INT32_MIN to INT32_MAX.
  */
-int32_t NetworkInterfaceSendStub( NetworkContext_t * pNetworkContext,
+int32_t NetworkInterfaceSendStub( void * pNetworkContext,
                                   const void * pBuffer,
                                   size_t bytesToSend );
 

--- a/test/cbmc/stubs/network_interface_stubs.c
+++ b/test/cbmc/stubs/network_interface_stubs.c
@@ -44,7 +44,7 @@
     #define MAX_NETWORK_RECV_TRIES    4
 #endif
 
-int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
+int32_t NetworkInterfaceReceiveStub( void * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRecv )
 {
@@ -75,7 +75,7 @@ int32_t NetworkInterfaceReceiveStub( NetworkContext_t * pNetworkContext,
     return bytesOrError;
 }
 
-int32_t NetworkInterfaceSendStub( NetworkContext_t * pNetworkContext,
+int32_t NetworkInterfaceSendStub( void * pNetworkContext,
                                   const void * pBuffer,
                                   size_t bytesToSend )
 {

--- a/test/unit-test/core_mqtt_serializer_utest.c
+++ b/test/unit-test/core_mqtt_serializer_utest.c
@@ -179,7 +179,7 @@ int suiteTearDown( int numFailures )
 /**
  * @brief Mock successful transport receive by reading data from a buffer.
  */
-static int32_t mockReceive( NetworkContext_t * pNetworkContext,
+static int32_t mockReceive( void * pNetworkContext,
                             void * pBuffer,
                             size_t bytesToRecv )
 {
@@ -205,7 +205,7 @@ static int32_t mockReceive( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive with no data available.
  */
-static int32_t mockReceiveNoData( NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveNoData( void * pNetworkContext,
                                   void * pBuffer,
                                   size_t bytesToRecv )
 {
@@ -220,7 +220,7 @@ static int32_t mockReceiveNoData( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive failure.
  */
-static int32_t mockReceiveFailure( NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveFailure( void * pNetworkContext,
                                    void * pBuffer,
                                    size_t bytesToRecv )
 {
@@ -235,7 +235,7 @@ static int32_t mockReceiveFailure( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mock transport receive that succeeds once, then fails.
  */
-static int32_t mockReceiveSucceedThenFail( NetworkContext_t * pNetworkContext,
+static int32_t mockReceiveSucceedThenFail( void * pNetworkContext,
                                            void * pBuffer,
                                            size_t bytesToRecv )
 {

--- a/test/unit-test/core_mqtt_state_utest.c
+++ b/test/unit-test/core_mqtt_state_utest.c
@@ -57,7 +57,7 @@ int suiteTearDown( int numFailures )
 
 /* ========================================================================== */
 
-static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvSuccess( void * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -66,7 +66,7 @@ static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
     return bytesToRead;
 }
 
-static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportSendSuccess( void * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -259,7 +259,7 @@ int suiteTearDown( int numFailures )
  * @brief Mock successful transport send, and write data into buffer for
  * verification.
  */
-static int32_t mockSend( NetworkContext_t * pNetworkContext,
+static int32_t mockSend( void * pNetworkContext,
                          const void * pMessage,
                          size_t bytesToSend )
 {
@@ -339,7 +339,7 @@ static uint32_t getTimeDummy( void )
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportWritevSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportWritevSuccess( void * pNetworkContext,
                                        TransportOutVector_t * pIoVectorIterator,
                                        size_t vectorsToBeSent )
 {
@@ -434,7 +434,7 @@ static void verifyEncodedTopicStringUnsubscribe( TransportOutVector_t * pIoVecto
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportWritevSubscribeSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportWritevSubscribeSuccess( void * pNetworkContext,
                                                 TransportOutVector_t * pIoVectorIterator,
                                                 size_t vectorsToBeSent )
 {
@@ -523,7 +523,7 @@ static int32_t transportWritevSubscribeSuccess( NetworkContext_t * pNetworkConte
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportWritevUnsubscribeSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportWritevUnsubscribeSuccess( void * pNetworkContext,
                                                   TransportOutVector_t * pIoVectorIterator,
                                                   size_t vectorsToBeSent )
 {
@@ -601,7 +601,7 @@ static int32_t transportWritevUnsubscribeSuccess( NetworkContext_t * pNetworkCon
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportWritevFail( NetworkContext_t * pNetworkContext,
+static int32_t transportWritevFail( void * pNetworkContext,
                                     TransportOutVector_t * pIoVectorIterator,
                                     size_t vectorsToBeSent )
 {
@@ -618,7 +618,7 @@ static int32_t transportWritevFail( NetworkContext_t * pNetworkContext,
     return bytesToWrite + 3;
 }
 
-static int32_t transportWritevError( NetworkContext_t * pNetworkContext,
+static int32_t transportWritevError( void * pNetworkContext,
                                      TransportOutVector_t * pIoVectorIterator,
                                      size_t vectorsToBeSent )
 {
@@ -640,7 +640,7 @@ static int32_t transportWritevError( NetworkContext_t * pNetworkContext,
  * @return Number of bytes sent; negative value on error;
  * 0 for timeout or 0 bytes sent.
  */
-static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportSendSuccess( void * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -652,7 +652,7 @@ static int32_t transportSendSuccess( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked failed transport send.
  */
-static int32_t transportSendFailure( NetworkContext_t * pNetworkContext,
+static int32_t transportSendFailure( void * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -665,7 +665,7 @@ static int32_t transportSendFailure( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport send that always returns 0 bytes sent.
  */
-static int32_t transportSendNoBytes( NetworkContext_t * pNetworkContext,
+static int32_t transportSendNoBytes( void * pNetworkContext,
                                      const void * pBuffer,
                                      size_t bytesToWrite )
 {
@@ -678,7 +678,7 @@ static int32_t transportSendNoBytes( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport send that succeeds then fails.
  */
-static int32_t transportSendSucceedThenFail( NetworkContext_t * pNetworkContext,
+static int32_t transportSendSucceedThenFail( void * pNetworkContext,
                                              const void * pMessage,
                                              size_t bytesToSend )
 {
@@ -700,7 +700,7 @@ static int32_t transportSendSucceedThenFail( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport send that only sends half of the bytes.
  */
-static int32_t transportWritevPartialByte( NetworkContext_t * pNetworkContext,
+static int32_t transportWritevPartialByte( void * pNetworkContext,
                                            TransportOutVector_t * pIoVectorIterator,
                                            size_t vectorsToBeSent )
 {
@@ -732,7 +732,7 @@ static int32_t transportWritevPartialByte( NetworkContext_t * pNetworkContext,
  *
  * @return Number of bytes received; negative value on error.
  */
-static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvSuccess( void * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -741,7 +741,7 @@ static int32_t transportRecvSuccess( NetworkContext_t * pNetworkContext,
     return bytesToRead;
 }
 
-static int32_t transportRecvOneSuccessOneFail( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvOneSuccessOneFail( void * pNetworkContext,
                                                void * pBuffer,
                                                size_t bytesToRead )
 {
@@ -762,7 +762,7 @@ static int32_t transportRecvOneSuccessOneFail( NetworkContext_t * pNetworkContex
 /**
  * @brief Mocked failed transport read.
  */
-static int32_t transportRecvFailure( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvFailure( void * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -775,7 +775,7 @@ static int32_t transportRecvFailure( NetworkContext_t * pNetworkContext,
 /**
  * @brief Mocked transport reading one byte at a time.
  */
-static int32_t transportRecvOneByte( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvOneByte( void * pNetworkContext,
                                      void * pBuffer,
                                      size_t bytesToRead )
 {
@@ -789,7 +789,7 @@ static int32_t transportRecvOneByte( NetworkContext_t * pNetworkContext,
  * @brief Mocked transport returning zero bytes to simulate reception
  * of no data over network.
  */
-static int32_t transportRecvNoData( NetworkContext_t * pNetworkContext,
+static int32_t transportRecvNoData( void * pNetworkContext,
                                     void * pBuffer,
                                     size_t bytesToRead )
 {


### PR DESCRIPTION
Specify separately from transport interface.

Using an opaque type with multiple definitions in a binary can cause a tonne of problems with debuggers. Use a void pointer to reduce the confusion here and allow transport implementations to use a more reasonable setup.