### PR TITLE
Change proof_ci runner to 64-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             config: .github/memory_statistics_config.json
             check_against: docs/doxygen/include/size_table.md
   proof_ci:
-    runs-on: cbmc_ubuntu-latest_32-core
+    runs-on: cbmc_ubuntu-latest_64-core
     steps:
       - name: Set up CBMC runner
         uses: FreeRTOS/CI-CD-Github-Actions/set_up_cbmc_runner@main


### PR DESCRIPTION
This is due to excessively long runtime on the previous 32-core machine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
