### PR TITLE
Fix timeout calculation in sendVector function to account for overflow

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -767,7 +767,7 @@ static int32_t sendMessageVector( MQTTContext_t * pContext,
                                   size_t ioVecCount )
 {
     int32_t sendResult;
-    uint32_t timeoutMs;
+    uint32_t startTime;
     TransportOutVector_t * pIoVectIterator;
     size_t vectorsToBeSent = ioVecCount;
     size_t bytesToSend = 0U;
@@ -788,8 +788,8 @@ static int32_t sendMessageVector( MQTTContext_t * pContext,
     /* Reset the iterator to point to the first entry in the array. */
     pIoVectIterator = pIoVec;
 
-    /* Set the timeout. */
-    timeoutMs = pContext->getTime() + MQTT_SEND_TIMEOUT_MS;
+    /* Note the start time. */
+    startTime = pContext->getTime();
 
     while( ( bytesSentOrError < ( int32_t ) bytesToSend ) && ( bytesSentOrError >= 0 ) )
     {
@@ -832,7 +832,7 @@ static int32_t sendMessageVector( MQTTContext_t * pContext,
         }
 
         /* Check for timeout. */
-        if( pContext->getTime() >= timeoutMs )
+        if( calculateElapsedTime( pContext->getTime(), startTime ) > MQTT_SEND_TIMEOUT_MS )
         {
             LogError( ( "sendMessageVector: Unable to send packet: Timed out." ) );
             break;
@@ -1701,7 +1701,7 @@ static MQTTStatus_t receiveSingleIteration( MQTTContext_t * pContext,
         pContext->index += ( size_t ) recvBytes;
 
         status = MQTT_ProcessIncomingPacketTypeAndLength( pContext->networkBuffer.pBuffer,
-                                                          &pContext->index,
+                                                          &( pContext->index ),
                                                           &incomingPacket );
 
         totalMQTTPacketLength = incomingPacket.remainingLength + incomingPacket.headerLength;

--- a/test/unit-test/core_mqtt_config.h
+++ b/test/unit-test/core_mqtt_config.h
@@ -77,4 +77,6 @@ struct NetworkContext
 
 #define MQTT_SUB_UNSUB_MAX_VECTORS    ( 6U )
 
+#define MQTT_SEND_TIMEOUT_MS          ( 20U )
+
 #endif /* ifndef CORE_MQTT_CONFIG_H_ */

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -4784,6 +4784,7 @@ void test_MQTT_Subscribe_error_paths_timerOverflowCheck( void )
     size_t packetSize = MQTT_SAMPLE_REMAINING_LENGTH;
 
     globalEntryTime = UINT32_MAX - MQTT_OVERFLOW_OFFSET;
+
     /* The timer function can be called a maximum of these many times
      * (which is way less than UINT32_MAX). This ensures that if overflow
      * check is not correct, then the timer mock call will fail and assert. */

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -330,7 +330,7 @@ static int32_t getTimeMockCallLimit = -1;
  */
 static uint32_t getTimeMock( void )
 {
-    TEST_ASSERT_GREATER_THAN_INT32( 0, getTimeMockCallLimit-- );
+    TEST_ASSERT_GREATER_THAN_INT32( -1, getTimeMockCallLimit-- );
     return globalEntryTime++;
 }
 
@@ -4642,53 +4642,6 @@ void test_MQTT_Subscribe_happy_path2( void )
     TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
 }
 
-/**
- * @brief This test case verifies that MQTT_Subscribe returns successfully
- * when valid parameters are passed and all bytes are sent when the getTime
- * function timer overflows.
- */
-void test_MQTT_Subscribe_happy_path_timerOverflow( void )
-{
-    MQTTStatus_t mqttStatus;
-    MQTTContext_t context = { 0 };
-    TransportInterface_t transport = { 0 };
-    MQTTFixedBuffer_t networkBuffer = { 0 };
-    MQTTSubscribeInfo_t subscribeInfo[ 2 ];
-    size_t remainingLength = MQTT_SAMPLE_REMAINING_LENGTH;
-    size_t packetSize = MQTT_SAMPLE_REMAINING_LENGTH;
-    MQTTPubAckInfo_t incomingRecords = { 0 };
-    MQTTPubAckInfo_t outgoingRecords = { 0 };
-
-    setupTransportInterface( &transport );
-    setupNetworkBuffer( &networkBuffer );
-    transport.send = transportSendSucceedThenFail;
-    transport.writev = NULL;
-    setupSubscriptionInfo( &subscribeInfo[ 0 ] );
-    setupSubscriptionInfo( &subscribeInfo[ 1 ] );
-
-    globalEntryTime = UINT32_MAX;
-
-    /* Initialize context. */
-    mqttStatus = MQTT_Init( &context, &transport, getTime, eventCallback, &networkBuffer );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-
-    mqttStatus = MQTT_InitStatefulQoS( &context,
-                                       &outgoingRecords, 4,
-                                       &incomingRecords, 4 );
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-
-    /* Verify MQTTSuccess is returned with the following mocks. */
-    MQTT_GetSubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
-    MQTT_GetSubscribePacketSize_ReturnThruPtr_pPacketSize( &packetSize );
-    MQTT_GetSubscribePacketSize_ReturnThruPtr_pRemainingLength( &remainingLength );
-    MQTT_SerializeSubscribeHeader_Stub( MQTT_SerializeSubscribedHeader_cb1 );
-
-    /* Expect the above calls when running MQTT_Subscribe. */
-    mqttStatus = MQTT_Subscribe( &context, subscribeInfo, 2, MQTT_FIRST_VALID_PACKET_ID );
-
-    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
-}
-
 void test_MQTT_Subscribe_MultipleSubscriptions( void )
 {
     MQTTStatus_t mqttStatus;
@@ -4834,7 +4787,7 @@ void test_MQTT_Subscribe_error_paths_timerOverflowCheck( void )
     /* The timer function can be called a maximum of these many times
      * (which is way less than UINT32_MAX). This ensures that if overflow
      * check is not correct, then the timer mock call will fail and assert. */
-    getTimeMockCallLimit = 1;
+    getTimeMockCallLimit = MQTT_SEND_TIMEOUT_MS + 1;
 
     /* Verify that an error is propagated when transport interface returns an error. */
     setupNetworkBuffer( &networkBuffer );

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -4783,7 +4783,7 @@ void test_MQTT_Subscribe_error_paths_timerOverflowCheck( void )
     size_t remainingLength = MQTT_SAMPLE_REMAINING_LENGTH;
     size_t packetSize = MQTT_SAMPLE_REMAINING_LENGTH;
 
-    globalEntryTime = UINT32_MAX - MQTT_OVERFLOW_OFFSET;
+    globalEntryTime = UINT32_MAX;
 
     /* The timer function can be called a maximum of these many times
      * (which is way less than UINT32_MAX). This ensures that if overflow

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -4800,7 +4800,7 @@ void test_MQTT_Subscribe_error_paths_timerOverflowCheck( void )
     size_t remainingLength = MQTT_SAMPLE_REMAINING_LENGTH;
     size_t packetSize = MQTT_SAMPLE_REMAINING_LENGTH;
 
-    globalEntryTime = UINT32_MAX;
+    globalEntryTime = UINT32_MAX - 2U;
 
     /* The timer function can be called a maximum of these many times
      * (which is way less than UINT32_MAX). This ensures that if overflow

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -325,7 +325,7 @@ static int32_t getTimeMockCallLimit = -1;
 /**
  * @brief A mocked timer query function that increments on every call. This
  * guarantees that only a single iteration runs in the ProcessLoop for ease
- * of testing. Additionally, this test whether the number of calls to this
+ * of testing. Additionally, this tests whether the number of calls to this
  * function have exceeded than the set limit and asserts.
  */
 static uint32_t getTimeMock( void )
@@ -333,6 +333,23 @@ static uint32_t getTimeMock( void )
     TEST_ASSERT_GREATER_THAN_INT32( -1, getTimeMockCallLimit-- );
     return globalEntryTime++;
 }
+
+static int32_t getTimeMockBigTimeStepCallLimit = -1;
+
+/**
+ * @brief A mocked timer query function that increments by MQTT_SEND_TIMEOUT_MS
+ * to simulate the time consumed by a long running high priority task on every
+ * call. Additionally, this tests whether the number of calls to this function
+ * have exceeded than the set limit and asserts.
+ */
+static uint32_t getTimeMockBigTimeStep( void )
+{
+    TEST_ASSERT_GREATER_THAN_INT32( -1, getTimeMockBigTimeStepCallLimit-- );
+
+    globalEntryTime += MQTT_SEND_TIMEOUT_MS;
+    return globalEntryTime;
+}
+
 
 /**
  * @brief A mocked timer function that could be used on a device with no system
@@ -4809,6 +4826,50 @@ void test_MQTT_Subscribe_error_paths_timerOverflowCheck( void )
     MQTT_SerializeSubscribeHeader_Stub( MQTT_SerializeSubscribedHeader_cb );
     mqttStatus = MQTT_Subscribe( &context, &subscribeInfo, 1, MQTT_FIRST_VALID_PACKET_ID );
     TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
+    TEST_ASSERT_EQUAL( -1, getTimeMockCallLimit );
+}
+
+/**
+ * @brief This test case verifies that MQTT_Subscribe returns MQTTSendFailed
+ * if transport interface send fails and timer overflows.
+ */
+void test_MQTT_Subscribe_error_paths_timerOverflowCheck1( void )
+{
+    MQTTStatus_t mqttStatus;
+    MQTTContext_t context = { 0 };
+    TransportInterface_t transport = { 0 };
+    MQTTFixedBuffer_t networkBuffer = { 0 };
+    MQTTSubscribeInfo_t subscribeInfo = { 0 };
+    size_t remainingLength = MQTT_SAMPLE_REMAINING_LENGTH;
+    size_t packetSize = MQTT_SAMPLE_REMAINING_LENGTH;
+
+    globalEntryTime = UINT32_MAX - MQTT_SEND_TIMEOUT_MS + 1;
+
+    /* The timer function can be called a exactly 2 times. First when setting
+     * the initial time, next time when checking for timeout.
+     */
+    getTimeMockBigTimeStepCallLimit = 2;
+
+    /* Verify that an error is propagated when transport interface returns an error. */
+    setupNetworkBuffer( &networkBuffer );
+    setupSubscriptionInfo( &subscribeInfo );
+    subscribeInfo.qos = MQTTQoS0;
+    setupTransportInterface( &transport );
+    transport.writev = NULL;
+    /* Case when there is timeout in sending data through transport send. */
+    transport.send = transportSendNoBytes; /* Use the mock function that returns zero bytes sent. */
+
+    /* Initialize context. */
+    mqttStatus = MQTT_Init( &context, &transport, getTimeMockBigTimeStep, eventCallback, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTSuccess, mqttStatus );
+
+    MQTT_GetSubscribePacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_GetSubscribePacketSize_ReturnThruPtr_pPacketSize( &packetSize );
+    MQTT_GetSubscribePacketSize_ReturnThruPtr_pRemainingLength( &remainingLength );
+    MQTT_SerializeSubscribeHeader_Stub( MQTT_SerializeSubscribedHeader_cb );
+    mqttStatus = MQTT_Subscribe( &context, &subscribeInfo, 1, MQTT_FIRST_VALID_PACKET_ID );
+    TEST_ASSERT_EQUAL( MQTTSendFailed, mqttStatus );
+    TEST_ASSERT_EQUAL( -1, getTimeMockBigTimeStepCallLimit );
 }
 
 /* ========================================================================== */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Currently, the `MQTTContext.getTime()` function returns a 32-bit value which represents the number of milliseconds elapsed since a given epoch. The code used a faulty comparison which did not account for overflow of the 32-bit value. This PR fixes that issue by using the predefined `calculateElapsedTime` function.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
