### PR TITLE
Fix race condition in handleKeepAlive

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -1344,6 +1344,7 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
     MQTTStatus_t status = MQTTSuccess;
     uint32_t now = 0U;
     uint32_t packetTxTimeoutMs = 0U;
+    uint32_t lastPacketTxTime = 0U;
 
     assert( pContext != NULL );
     assert( pContext->getTime != NULL );
@@ -1369,7 +1370,11 @@ static MQTTStatus_t handleKeepAlive( MQTTContext_t * pContext )
     }
     else
     {
-        if( ( packetTxTimeoutMs != 0U ) && ( calculateElapsedTime( now, pContext->lastPacketTxTime ) >= packetTxTimeoutMs ) )
+        MQTT_PRE_STATE_UPDATE_HOOK( pContext );
+        lastPacketTxTime = pContext->lastPacketTxTime;
+        MQTT_POST_STATE_UPDATE_HOOK( pContext );
+
+        if( ( packetTxTimeoutMs != 0U ) && ( calculateElapsedTime( now, lastPacketTxTime ) >= packetTxTimeoutMs ) )
         {
             status = MQTT_Ping( pContext );
         }


### PR DESCRIPTION
<!--- Title -->
Fix race condition in handleKeepAlive

Description
-----------
The code for handleKeepAlive() (which is invoked as part of MQTT_ProcessLoop()) does not invoke the STATE_UPDATE_HOOK macros, but still reads from pContext->lastPacketTxTime. Therefore, this causes a RW race condition which is picked up by ThreadAnalyzer. With a sufficiently meddlesome scheduler, the value of lastPacketTxTime could be different for each time it is checked inside of handleKeepAlive() , causing unreliable behavior in the transmission of KeepAlive packets.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
