### PR TITLE
Update CMakeList to optionally build UT/Coverity; Update coverity configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           -G "Unix Makefiles" \
           -DCMAKE_BUILD_TYPE=Debug \
           -DBUILD_CLONE_SUBMODULES=ON \
+          -DUNITTEST=1 \
           -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Werror -DNDEBUG -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
           make -C build/ all
           echo "::endgroup::"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required ( VERSION 3.13.0 )
-project ( "CoreMQTT unit test"
+cmake_minimum_required ( VERSION 3.22.0 )
+project ( "CoreMQTT tests"
           VERSION 1.0.0
           LANGUAGES C )
 
@@ -12,6 +12,12 @@ if( NOT DEFINED CMAKE_C_STANDARD )
 endif()
 if( NOT DEFINED CMAKE_C_STANDARD_REQUIRED )
     set( CMAKE_C_STANDARD_REQUIRED ON )
+endif()
+
+# If no configuration is defined, turn everythin on.
+if( NOT DEFINED COV_ANALYSIS AND NOT DEFINED UNITTEST )
+    set( COV_ANALYSIS TRUE )
+    set( UNITTEST TRUE )
 endif()
 
 # Do not allow in-source build.
@@ -35,61 +41,67 @@ set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 
 # ===================================== Coverity Analysis Configuration =================================================
 
-# Include filepaths for source and include.
-include( ${MODULE_ROOT_DIR}/mqttFilePaths.cmake )
+if( COV_ANALYSIS )
+    # Include filepaths for source and include.
+    include( ${MODULE_ROOT_DIR}/mqttFilePaths.cmake )
 
-# Target for Coverity analysis that builds the library.
-add_library( coverity_analysis
-             ${MQTT_SOURCES}
-             ${MQTT_SERIALIZER_SOURCES} )
+    # Target for Coverity analysis that builds the library.
+    add_library( coverity_analysis
+                ${MQTT_SOURCES}
+                ${MQTT_SERIALIZER_SOURCES} )
 
-# Build MQTT library target without custom config dependency.
-target_compile_definitions( coverity_analysis PUBLIC MQTT_DO_NOT_USE_CUSTOM_CONFIG=1 )
-target_compile_definitions( coverity_analysis PUBLIC NDEBUG=1 )
+    # Build MQTT library target without custom config dependency.
+    target_compile_definitions( coverity_analysis PUBLIC MQTT_DO_NOT_USE_CUSTOM_CONFIG=1 )
 
-# MQTT public include path.
-target_include_directories( coverity_analysis PUBLIC ${MQTT_INCLUDE_PUBLIC_DIRS} )
+    # MQTT public include path.
+    target_include_directories( coverity_analysis PUBLIC ${MQTT_INCLUDE_PUBLIC_DIRS} )
 
-#  ====================================  Test Configuration ========================================
-
-# Define a CMock resource path.
-set( CMOCK_DIR ${MODULE_ROOT_DIR}/test/unit-test/CMock CACHE INTERNAL "CMock library source directory." )
-
-# Include CMock build configuration.
-include( unit-test/cmock_build.cmake )
-
-# Check if the CMock source directory exists, and if not present, clone the submodule
-# if BUILD_CLONE_SUBMODULES configuration is enabled.
-if( NOT EXISTS ${CMOCK_DIR}/src )
-    # Attempt to clone CMock.
-    if( ${BUILD_CLONE_SUBMODULES} )
-        clone_cmock()
-    else()
-        message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
-    endif()
+    # Remove inclusion of assert.
+    add_compile_definitions( NDEBUG=1 )
 endif()
 
-# Add unit test and coverage configuration.
+#  ====================================  Test Configuration ========================================
+if( UNITTEST )
+    # Define a CMock resource path.
+    set( CMOCK_DIR ${MODULE_ROOT_DIR}/test/unit-test/CMock CACHE INTERNAL "CMock library source directory." )
 
-# Use CTest utility for managing test runs. This has to be added BEFORE
-# defining test targets with add_test()
-enable_testing()
+    # Include CMock build configuration.
+    include( unit-test/cmock_build.cmake )
 
-# Add build targets for CMock and Unit, required for unit testing.
-add_cmock_targets()
+    # Check if the CMock source directory exists, and if not present, clone the submodule
+    # if BUILD_CLONE_SUBMODULES configuration is enabled.
+    if( NOT EXISTS ${CMOCK_DIR}/src )
+        # Attempt to clone CMock.
+        if( ${BUILD_CLONE_SUBMODULES} )
+            clone_cmock()
+        else()
+            message( FATAL_ERROR "The required submodule CMock does not exist. Either clone it manually, or set\
+                                  BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+        endif()
+    endif()
 
-# Add function to enable CMock based tests and coverage.
-include( ${MODULE_ROOT_DIR}/tools/cmock/create_test.cmake )
+    # Add unit test and coverage configuration.
 
-# Include build configuration for unit tests.
-add_subdirectory( unit-test )
+    # Use CTest utility for managing test runs. This has to be added BEFORE
+    # defining test targets with add_test()
+    enable_testing()
 
-#  ==================================== Coverage Analysis configuration ========================================
+    # Add build targets for CMock and Unit, required for unit testing.
+    add_cmock_targets()
 
-# Add a target for running coverage on tests.
-add_custom_target( coverage
-    COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
-    -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
-    DEPENDS cmock unity core_mqtt_utest core_mqtt_serializer_utest core_mqtt_state_utest
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-)
+    # Add function to enable CMock based tests and coverage.
+    include( ${MODULE_ROOT_DIR}/tools/cmock/create_test.cmake )
+
+    # Include build configuration for unit tests.
+    add_subdirectory( unit-test )
+
+    #  ==================================== Coverage Analysis configuration ========================================
+
+    # Add a target for running coverage on tests.
+    add_custom_target( coverage
+        COMMAND ${CMAKE_COMMAND} -DCMOCK_DIR=${CMOCK_DIR}
+        -P ${MODULE_ROOT_DIR}/tools/cmock/coverage.cmake
+        DEPENDS cmock unity core_mqtt_utest core_mqtt_serializer_utest core_mqtt_state_utest
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required ( VERSION 3.22.0 )
 project ( "CoreMQTT tests"
-          VERSION 1.0.0
+          VERSION 2.1.0
           LANGUAGES C )
 
 # Allow the project to be organized into folders.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ if( NOT DEFINED CMAKE_C_STANDARD_REQUIRED )
     set( CMAKE_C_STANDARD_REQUIRED ON )
 endif()
 
-# If no configuration is defined, turn everythin on.
+# If no configuration is defined, turn everything on.
 if( NOT DEFINED COV_ANALYSIS AND NOT DEFINED UNITTEST )
     set( COV_ANALYSIS TRUE )
     set( UNITTEST TRUE )

--- a/tools/coverity/misra.config
+++ b/tools/coverity/misra.config
@@ -1,43 +1,40 @@
-// MISRA C-2012 Rules
-
 {
-    version : "2.0",
-    standard : "c2012",
-    title: "Coverity MISRA Configuration",
-    deviations : [
-        // Disable the following rules.
+    "version" : "2.0",
+    "standard" : "c2012",
+    "title": "Coverity MISRA Configuration",
+    "deviations" : [
         {
-            deviation: "Directive 4.8",
-            reason: "Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file."
+            "deviation": "Directive 4.8",
+            "reason": "Allow inclusion of unused types. Header files for a specific port, which are needed by all files, may define types that are not used by a specific file."
         },
         {
-            deviation: "Directive 4.9",
-            reason: "Allow inclusion of function like macros. Logging is done using function like macros."
+            "deviation": "Directive 4.9",
+            "reason": "Allow inclusion of function like macros. Logging is done using function like macros."
         },
         {
-            deviation: "Rule 2.3",
-            reason: "Allow unused types. Library headers may define types intended for the application's use, but not used within the library files."
+            "deviation": "Rule 2.3",
+            "reason": "Allow unused types. Library headers may define types intended for the application's use, but not used within the library files."
         },
         {
-            deviation: "Rule 2.4",
-            reason: "Allow unused tags. Some compilers warn if types are not tagged."
+            "deviation": "Rule 2.4",
+            "reason": "Allow unused tags. Some compilers warn if types are not tagged."
         },
         {
-            deviation: "Rule 2.5",
-            reason: "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
+            "deviation": "Rule 2.5",
+            "reason": "Allow unused macros. Library headers may define macros intended for the application's use, but not used by a specific file."
         },
         {
-            deviation: "Rule 3.1",
-            reason: "Allow nested comments. Documentation blocks contain comments for example code."
+            "deviation": "Rule 3.1",
+            "reason": "Allow nested comments. Documentation blocks contain comments for example code."
         },
         {
-            deviation: "Rule 8.7",
-            reason: "API functions are not used by the library outside of the files they are defined; however, they must be externally visible in order to be used by an application."
+            "deviation": "Rule 8.7",
+            "reason": "API functions are not used by the library outside of the files they are defined; however, they must be externally visible in order to be used by an application."
         },
         {
-            deviation: "Rule 11.5",
-            reason: "Allow casts from `void *`. The payload buffers are stored as `void *` and are cast to various types for use in functions."
-        },
+            "deviation": "Rule 11.5",
+            "reason": "Allow casts from `void *`. The payload buffers are stored as `void *` and are cast to various types for use in functions."
+        }
     ]
 }
 


### PR DESCRIPTION
Update Coverity configuration to meet the latest coverity standard.
Updated CMakelist to only build Coverity if required instead of building the CMock based unit tests as well.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
