### PR TITLE
Add a library.json file for PlatformIO to use

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,7 +8,11 @@
     "url": "https://github.com/FreeRTOS/coreMQTT.git"
   },
   "license": "MIT",
-  "headers": ["core_mqtt.h", "core_mqtt_serializer.h", "transport_interface.h"],
+  "headers": [
+    "core_mqtt.h",
+    "core_mqtt_serializer.h",
+    "transport_interface.h"
+  ],
   "build": {
     "flags": ["-Isource/include", "-Isource/interface"],
     "srcDir": "source"

--- a/library.json
+++ b/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "coreMQTT",
+  "version": "main",
+  "description": "portable, embedded friendly MQTT client library",
+  "homepage": "https://freertos.github.io/coreMQTT/",
+  "repository": "https://github.com/FreeRTOS/coreMQTT.git",
+  "license": "MIT",
+  "headers": ["core_mqtt.h", "core_mqtt_serializer.h", "transport_interface.h"],
+  "build": {
+    "flags": ["-Isource/include", "-Isource/interface"],
+    "srcDir": "source"
+  }
+}

--- a/library.json
+++ b/library.json
@@ -3,7 +3,10 @@
   "version": "main",
   "description": "portable, embedded friendly MQTT client library",
   "homepage": "https://freertos.github.io/coreMQTT/",
-  "repository": "https://github.com/FreeRTOS/coreMQTT.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FreeRTOS/coreMQTT.git"
+  },
   "license": "MIT",
   "headers": ["core_mqtt.h", "core_mqtt_serializer.h", "transport_interface.h"],
   "build": {


### PR DESCRIPTION
[PlatformIO](https://platformio.org/) is an increasingly popular open source build system for embedded development, supporting many frameworks, targets and environments. (I am not affiliated in any way with PlatformIO, I'm just a user.)

PlatformIO has a [library registry](https://registry.platformio.org/) that describes a large number of libraries which can potentially be reused. (This is analogous to [Arduino's library registry](https://github.com/arduino/library-registry?tab=readme-ov-file), but more flexible and general.)

PlatformIO can pull directly from the git repo, [but it needs a `library.json` file](https://docs.platformio.org/en/latest/manifests/library-json/index.html) giving a brief synopsis of the library and some basic build instructions. As you can see it's quite straightforward, especially since this particular library is very easy to build.

This doesn't touch ANY other code within the repository, so I don't think unit testing is needed. (We could potentially add a test to verify that `library.json` exists and is valid JSON?) I have manually tested by pulling it into a PlatformIO build from my fork.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thank you for your consideration!
