### PR TITLE
Fix time comparison overflow

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -864,7 +864,7 @@ static int32_t sendBuffer( MQTTContext_t * pContext,
                            size_t bytesToSend )
 {
     int32_t sendResult;
-    uint32_t timeoutMs;
+    uint32_t startTime;
     int32_t bytesSentOrError = 0;
     const uint8_t * pIndex = pBufferToSend;
 
@@ -874,7 +874,7 @@ static int32_t sendBuffer( MQTTContext_t * pContext,
     assert( pIndex != NULL );
 
     /* Set the timeout. */
-    timeoutMs = pContext->getTime() + MQTT_SEND_TIMEOUT_MS;
+    startTime = pContext->getTime();
 
     while( ( bytesSentOrError < ( int32_t ) bytesToSend ) && ( bytesSentOrError >= 0 ) )
     {
@@ -909,7 +909,7 @@ static int32_t sendBuffer( MQTTContext_t * pContext,
         }
 
         /* Check for timeout. */
-        if( pContext->getTime() >= timeoutMs )
+        if( calculateElapsedTime( pContext->getTime(), startTime ) >= ( MQTT_SEND_TIMEOUT_MS ) )
         {
             LogError( ( "sendBuffer: Unable to send packet: Timed out." ) );
             break;


### PR DESCRIPTION
Fix time comparison in sendBuffer after overflow

Description
-----------

Fixes https://github.com/FreeRTOS/coreMQTT/issues/286

Previously, a time overflow could cause the comparison to fail, and cause a
failed sendBuffer. Now, the code compares against the duration rather than
against the specific timepoint. Since signed overflow/underflow is defined,
subtracting to get the duration is okay as long as the duration fits in the
integer type.

Test Steps
-----------

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

https://github.com/FreeRTOS/coreMQTT/issues/286

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
