### PR TITLE
Update the mqtt.tag file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ locations below:
 |                                                       Location                                                       |
 | :------------------------------------------------------------------------------------------------------------------: |
 | [AWS IoT Device SDK for Embedded C](https://github.com/aws/aws-iot-device-sdk-embedded-C#releases-and-documentation) |
-|       [FreeRTOS.org](https://freertos.org/Documentation/api-ref/coreMQTT/docs/doxygen/output/html/index.html)        |
+|       [API Reference](https://freertos.github.io/coreMQTT/main/index.html)        |
 
 Note that the latest included version of coreMQTT may differ across
 repositories.

--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -2339,7 +2339,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = docs/doxygen/output/mqtt.tag
+GENERATE_TAGFILE       = docs/doxygen/output/html/mqtt.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
Description
-----------
The `mqtt.tag` was generated at `coreMQTT/docs/doxygen/output/mqtt.tag`. The [doxygen-generation](https://github.com/FreeRTOS/CI-CD-Github-Actions/tree/main/doxygen-generation) GH action deploys the content of `coreMQTT/docs/doxygen/output/html` and as a result, the `mqtt.tag` was not getting deployed.

This change updates the location of `mqtt.tag` to `coreMQTT/docs/doxygen/output/html/mqtt.tag` to ensure that it gets deployed by the doxygen-generation GH action.

Test Steps
-----------
Generated the doxygen documentation locally. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [NA] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
NA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
