### PR TITLE
Express the need of a non-blocking TransportRecv_t

### DIFF
--- a/docs/doxygen/porting.dox
+++ b/docs/doxygen/porting.dox
@@ -55,6 +55,8 @@ struct NetworkContext {
 };
 @endcode
 
+Please note that it is HIGHLY RECOMMENDED that the transport receive implementation does NOT block.
+
 @section mqtt_porting_time Time Function
 @brief The MQTT library relies on a function to generate millisecond timestamps, for the
 purpose of calculating durations and timeouts, as well as maintaining the keep-alive mechanism

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -200,9 +200,9 @@ typedef struct NetworkContext NetworkContext_t;
  * implementation does NOT block.
  * coreMQTT will continue to call the transport interface if it receives
  * a partial packet until it accumulates enough data to get the complete
- * MQTT packet. 
- * A non‐blocking implementation is also essential so that the library's inbuilt 
- * keep‐alive mechanism can work properly, given the user chooses to use 
+ * MQTT packet.
+ * A non‐blocking implementation is also essential so that the library's inbuilt
+ * keep‐alive mechanism can work properly, given the user chooses to use
  * that over their own keep alive mechanism.
  *
  * @param[in] pNetworkContext Implementation-defined network context.

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -198,7 +198,7 @@ typedef struct NetworkContext NetworkContext_t;
  *
  * @note It is HIGHLY RECOMMENDED that the transport receive
  * implementation does NOT block.
- * A non‐blocking implementation is essential so that the keep‐alive 
+ * A non‐blocking implementation is essential so that the keep‐alive
  * mechanism can work properly.
  * coreMQTT will continue to call the transport interface if it receives
  * a partial packet until it accumulates enough data to get the complete

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -96,6 +96,7 @@
  * without TLS, it is typically implemented by calling the TCP layer receive
  * function. @ref TransportRecv_t may be invoked multiple times by the protocol
  * library, if fewer bytes than were requested to receive are returned.
+ * Please note that it is HIGHLY RECOMMENDED that the transport receive implementation does NOT block.
  * <br><br>
  * <b>Example code:</b>
  * @code{c}
@@ -197,6 +198,8 @@ typedef struct NetworkContext NetworkContext_t;
  *
  * @note It is HIGHLY RECOMMENDED that the transport receive
  * implementation does NOT block.
+ * A non‐blocking implementation is essential so that the keep‐alive 
+ * mechanism can work properly.
  * coreMQTT will continue to call the transport interface if it receives
  * a partial packet until it accumulates enough data to get the complete
  * MQTT packet.

--- a/source/interface/transport_interface.h
+++ b/source/interface/transport_interface.h
@@ -198,11 +198,12 @@ typedef struct NetworkContext NetworkContext_t;
  *
  * @note It is HIGHLY RECOMMENDED that the transport receive
  * implementation does NOT block.
- * A non‐blocking implementation is essential so that the keep‐alive
- * mechanism can work properly.
  * coreMQTT will continue to call the transport interface if it receives
  * a partial packet until it accumulates enough data to get the complete
- * MQTT packet.
+ * MQTT packet. 
+ * A non‐blocking implementation is also essential so that the library's inbuilt 
+ * keep‐alive mechanism can work properly, given the user chooses to use 
+ * that over their own keep alive mechanism.
  *
  * @param[in] pNetworkContext Implementation-defined network context.
  * @param[in] pBuffer Buffer to receive the data into.


### PR DESCRIPTION
Express the need of a non-blocking TransportRecv_t #317

Description
-----------
- changed documentation to express the need of a non-blocking TransportRecv_t 
- mentioned that a non-blocking implementation is highly recommended in porting.dox and in the transportinterface
- did go more into detail in TransportRecv_t what the effects of a blocking recv implementation are

Test Steps
-----------
only changed documentation

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#317 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
