### PR TITLE
Fix timeout check ordering in sendMessageVector

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -875,8 +875,10 @@ static int32_t sendMessageVector( MQTTContext_t * pContext,
             pIoVectIterator->iov_len -= ( size_t ) sendResult;
         }
 
-                /* Check for timeout. */
-        if( calculateElapsedTime( pContext->getTime(), startTime ) > MQTT_SEND_TIMEOUT_MS )
+        /* Check for timeout. */
+        if( ( bytesSentOrError < ( int32_t ) bytesToSend ) &&
+            ( bytesSentOrError >= 0 ) &&
+            ( calculateElapsedTime( pContext->getTime(), startTime ) > MQTT_SEND_TIMEOUT_MS ) )
         {
             LogError( ( "sendMessageVector: Unable to send packet: Timed out." ) );
             break;

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -851,13 +851,6 @@ static int32_t sendMessageVector( MQTTContext_t * pContext,
             /* MISRA Empty body */
         }
 
-        /* Check for timeout. */
-        if( calculateElapsedTime( pContext->getTime(), startTime ) > MQTT_SEND_TIMEOUT_MS )
-        {
-            LogError( ( "sendMessageVector: Unable to send packet: Timed out." ) );
-            break;
-        }
-
         /* Update the send pointer to the correct vector and offset. */
         while( ( pIoVectIterator <= &( pIoVec[ ioVecCount - 1U ] ) ) &&
                ( sendResult >= ( int32_t ) pIoVectIterator->iov_len ) )
@@ -880,6 +873,13 @@ static int32_t sendMessageVector( MQTTContext_t * pContext,
         {
             pIoVectIterator->iov_base = ( const void * ) &( ( ( const uint8_t * ) pIoVectIterator->iov_base )[ sendResult ] );
             pIoVectIterator->iov_len -= ( size_t ) sendResult;
+        }
+
+                /* Check for timeout. */
+        if( calculateElapsedTime( pContext->getTime(), startTime ) > MQTT_SEND_TIMEOUT_MS )
+        {
+            LogError( ( "sendMessageVector: Unable to send packet: Timed out." ) );
+            break;
         }
     }
 


### PR DESCRIPTION
Fix timeout check ordering in sendMessageVector

Description
-----------
I am running your library with MQTT_SEND_TIMEOUT_MS=0. My intention is to not block at all when attempting a send. 
The library is running in a RTOS thread, and the getTimeFunction is returning the RTOS tick timer value (which is updated in another thread). In this scenario, the writev transport function successfully completed the requested send. But during the send, the other thread incremented the timer once. This means, that when this line executes:
`if( calculateElapsedTime( pContext->getTime(), startTime ) > MQTT_SEND_TIMEOUT_MS )`
the code considers the timeout elapsed, and breaks from the while loop, _before_ advancing pIoVectIterator and decrementing vectorsToBeSent.  This means that the packet was sent, but it isn't cleared from the pending vectors.

The fix is to move the calculateElapsedTime to the very end of the while loop, after the vect state is advanced.

Test Steps
-----------
Set MQTT_SEND_TIMEOUT_MS 0. Observe logs: "sendMessageVector: Unable to send packet: Timed out." , but also add to this log the values of bytesSentOrError and bytesToSend. Eventually, you will see a log where the timeout is reported, but bytesSentOrError ==bytesToSend. Or add assertion in the body of the if( calculateElapsedTime.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
