### PR TITLE
Modify SUBACK/UNSUBACK handling to not return ServerRefused on non-malformed packets

### DIFF
--- a/docs/doxygen/include/size_table.md
+++ b/docs/doxygen/include/size_table.md
@@ -19,7 +19,7 @@
     </tr>
     <tr>
         <td>core_mqtt_serializer.c</td>
-        <td><center>9.4K</center></td>
+        <td><center>9.5K</center></td>
         <td><center>7.3K</center></td>
     </tr>
     <tr>
@@ -39,7 +39,7 @@
     </tr>
     <tr>
         <td><b>Total estimates</b></td>
-        <td><b><center>23.0K</center></b></td>
+        <td><b><center>23.1K</center></b></td>
         <td><b><center>18.8K</center></b></td>
     </tr>
 </table>

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -615,12 +615,20 @@ static void addSubscriptionOptions( const MQTTSubscribeInfo_t subscriptionInfo,
                                     size_t currentOptionIndex );
 
 /**
- * @brief Handle Incoming Subscribe ACK
+ * @brief Handle incoming SUBACK or UNSUBACK packet.
+ *
+ * Deserializes the packet and invokes the application callback. Server
+ * rejection of individual topic filters (reason codes >= 0x80) is not
+ * treated as a library-level error; the application can inspect per-topic
+ * reason codes via #MQTTDeserializedInfo_t.pReasonCode in the callback.
  *
  * @param[in] pContext MQTT Connection context.
- * @param[in] pIncomingPacket Information of incoming packet
+ * @param[in] pIncomingPacket Information of incoming packet.
  *
- * @return #MQTTSuccess, #MQTTServerRefused, #MQTTBadResponse, #MQTTBadParameter, #MQTTEventCallbackFailed.
+ * @return #MQTTSuccess on successful deserialization (including server refusal);
+ * #MQTTBadResponse if the packet is malformed;
+ * #MQTTBadParameter if parameters are invalid;
+ * #MQTTEventCallbackFailed if the application callback returns false.
  */
 static MQTTStatus_t handleSubUnsubAck( MQTTContext_t * pContext,
                                        MQTTPacketInfo_t * pIncomingPacket );
@@ -4024,7 +4032,7 @@ static MQTTStatus_t handleSubUnsubAck( MQTTContext_t * pContext,
     LogInfo( ( "Ack packet deserialized with result: %s.",
                MQTT_Status_strerror( status ) ) );
 
-    if( ( status == MQTTSuccess ) || ( status == MQTTServerRefused ) )
+    if( status == MQTTSuccess )
     {
         deserializedInfo.packetIdentifier = packetIdentifier;
         deserializedInfo.deserializationResult = status;

--- a/source/core_mqtt_serializer.c
+++ b/source/core_mqtt_serializer.c
@@ -284,7 +284,7 @@ static MQTTStatus_t processPublishFlags( uint8_t publishFlags,
  * @param[out]  pSessionPresent Whether a previous session was present.
  * @param[out]  pPropBuffer MQTTPropBuilder_t to store the deserialized properties.
  *
- * @return #MQTTBadParameter, #MQTTBadResponse, #MQTTSuccess, #MQTTServerRefused
+ * @return #MQTTBadParameter, #MQTTBadResponse, or #MQTTSuccess.
  */
 static MQTTStatus_t deserializeConnack( MQTTConnectionProperties_t * pConnackProperties,
                                         const MQTTPacketInfo_t * pIncomingPacket,
@@ -294,10 +294,14 @@ static MQTTStatus_t deserializeConnack( MQTTConnectionProperties_t * pConnackPro
 /**
  * @brief Decode the status bytes of a SUBACK packet to a #MQTTStatus_t.
  *
+ * All known reason codes (including server rejections >= 0x80) are treated
+ * as successful deserialization. The application can inspect individual
+ * reason codes via #MQTTReasonCodeInfo_t in the event callback.
+ *
  * @param[in] statusCount Number of status bytes in the SUBACK.
  * @param[in] pStatusStart The first status byte in the SUBACK.
  * @param[out] pReasonCodes The #MQTTReasonCodeInfo_t to store reason codes for each topic filter.
- * @return #MQTTSuccess, #MQTTServerRefused, or #MQTTBadResponse.
+ * @return #MQTTSuccess or #MQTTBadResponse.
  */
 static MQTTStatus_t readSubackStatus( size_t statusCount,
                                       const uint8_t * pStatusStart,
@@ -312,7 +316,7 @@ static MQTTStatus_t readSubackStatus( size_t statusCount,
  *                           Contains the success/failure status of the corresponding request.
  * @param[out]  pPropBuffer MQTTPropBuilder_t to store the deserialized properties.
  *
- * @return #MQTTBadParameter, #MQTTBadResponse, #MQTTSuccess, #MQTTServerRefused
+ * @return #MQTTBadParameter, #MQTTBadResponse, or #MQTTSuccess.
  */
 static MQTTStatus_t deserializeSubUnsubAck( const MQTTPacketInfo_t * incomingPacket,
                                             uint16_t * pPacketId,
@@ -1771,7 +1775,7 @@ static MQTTStatus_t readSubackStatus( size_t statusCount,
                                       const uint8_t * pStatusStart,
                                       MQTTReasonCodeInfo_t * pReasonCodes )
 {
-    MQTTStatus_t status = MQTTServerRefused;
+    MQTTStatus_t status = MQTTSuccess;
     uint8_t subscriptionStatus = 0;
     size_t i = 0;
 
@@ -1789,7 +1793,6 @@ static MQTTStatus_t readSubackStatus( size_t statusCount,
                 LogDebug( ( "Topic Filter %lu accepted, max QoS %u.",
                             ( unsigned long ) i,
                             ( unsigned int ) subscriptionStatus ) );
-                status = MQTTSuccess;
                 break;
 
             case 0x80:
@@ -1841,7 +1844,7 @@ static MQTTStatus_t readSubackStatus( size_t statusCount,
         }
     }
 
-    if( ( status == MQTTSuccess ) || ( status == MQTTServerRefused ) )
+    if( status == MQTTSuccess )
     {
         pReasonCodes->reasonCode = pStatusStart;
         pReasonCodes->reasonCodeLength = statusCount;

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -970,6 +970,10 @@ MQTTStatus_t MQTT_Subscribe( MQTTContext_t * pContext,
  * #MQTTStatusNotConnected if the connection is not established yet<br>
  * #MQTTStatusDisconnectPending if the user is expected to call MQTT_Disconnect
  * before calling any other API<br>
+ * #MQTTNoMemory if the outgoing publish record array is full<br>
+ * #MQTTStateCollision if a QoS > 0 publish with the same packet ID already
+ * exists in the state records and the duplicate flag is not set<br>
+ * #MQTTIllegalState if the state machine update after sending fails<br>
  * #MQTTPublishStoreFailed if the user provided callback to copy and store the
  * outgoing publish packet fails<br>
  * #MQTTSuccess otherwise.<br>
@@ -1157,10 +1161,7 @@ MQTTStatus_t MQTT_Unsubscribe( MQTTContext_t * pContext,
  * #MQTTBadParameter if invalid parameters are passed;<br>
  * #MQTTBadResponse if invalid properties are parsed;<br>
  * #MQTTSendFailed if transport send failed;<br>
- * #MQTTStatusNotConnected if the connection is not established yet and a PING
- * or an ACK is being sent.<br>
- * #MQTTStatusDisconnectPending if the user is expected to call MQTT_Disconnect
- * before calling any other API<br>
+ * #MQTTStatusNotConnected if the connection is not established yet.<br>
  * #MQTTSuccess otherwise.<br>
  *
  * Functions to add optional properties to the DISCONNECT packet are:
@@ -1218,7 +1219,12 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext,
  * #MQTTEventCallback_t callback does not contain blocking operations to prevent potential
  * non-deterministic blocking period of the #MQTT_ProcessLoop API call.
  *
- * @return #MQTTBadParameter if context is NULL;
+ * @return #MQTTSuccess on success;
+ * #MQTTNeedMoreBytes if an incomplete packet has been received. The caller
+ * should call this function again (probably after a delay) to receive the
+ * remaining data. Both #MQTTSuccess and #MQTTNeedMoreBytes indicate normal
+ * operation — all other return values indicate an error.<br>
+ * #MQTTBadParameter if context is NULL;
  * #MQTTRecvFailed if a network error occurs during reception;
  * #MQTTSendFailed if a network error occurs while sending an ACK or PINGREQ;
  * #MQTTBadResponse if an invalid packet is received;
@@ -1226,13 +1232,15 @@ MQTTStatus_t MQTT_Disconnect( MQTTContext_t * pContext,
  * #MQTT_PINGRESP_TIMEOUT_MS milliseconds;
  * #MQTTIllegalState if an incoming QoS 1/2 publish or ack causes an
  * invalid transition for the internal state machine;
- * #MQTTNeedMoreBytes if MQTT_ProcessLoop has received
- * incomplete data; it should be called again (probably after a delay);
+ * #MQTTNoMemory if the incoming publish record array is full when
+ * receiving a QoS 1/2 publish;
  * #MQTTStatusNotConnected if the connection is not established yet and a PING
- * or an ACK is being sent.
+ * or an ACK is being sent;
  * #MQTTStatusDisconnectPending if the user is expected to call MQTT_Disconnect
- * before calling any other API
- * #MQTTSuccess on success.
+ * before calling any other API;
+ * #MQTTPublishStoreFailed if the user provided store function for
+ * retransmission failed while storing an outgoing acknowledgment;
+ * #MQTTEventCallbackFailed if the application callback returns false.
  *
  * <b>Example</b>
  * @code{c}
@@ -1280,15 +1288,26 @@ MQTTStatus_t MQTT_ProcessLoop( MQTTContext_t * pContext );
  * #MQTTEventCallback_t callback does not contain blocking operations to prevent potential
  * non-deterministic blocking period of the #MQTT_ReceiveLoop API call.
  *
- * @return #MQTTBadParameter if context is NULL;
+ * @return #MQTTSuccess on success;
+ * #MQTTNeedMoreBytes if an incomplete packet has been received. The caller
+ * should call this function again (probably after a delay) to receive the
+ * remaining data. Both #MQTTSuccess and #MQTTNeedMoreBytes indicate normal
+ * operation — all other return values indicate an error.<br>
+ * #MQTTBadParameter if context is NULL;
  * #MQTTRecvFailed if a network error occurs during reception;
  * #MQTTSendFailed if a network error occurs while sending an ACK or PINGREQ;
  * #MQTTBadResponse if an invalid packet is received;
  * #MQTTIllegalState if an incoming QoS 1/2 publish or ack causes an
  * invalid transition for the internal state machine;
- * #MQTTNeedMoreBytes if MQTT_ReceiveLoop has received
- * incomplete data; it should be called again (probably after a delay);
- * #MQTTSuccess on success.
+ * #MQTTNoMemory if the incoming publish record array is full when
+ * receiving a QoS 1/2 publish;
+ * #MQTTStatusNotConnected if the connection is not established yet and an
+ * ACK is being sent;
+ * #MQTTStatusDisconnectPending if the user is expected to call MQTT_Disconnect
+ * before calling any other API;
+ * #MQTTPublishStoreFailed if the user provided store function for
+ * retransmission failed while storing an outgoing acknowledgment;
+ * #MQTTEventCallbackFailed if the application callback returns false.
  *
  * <b>Example</b>
  * @code{c}
@@ -1331,7 +1350,7 @@ MQTTStatus_t MQTT_ReceiveLoop( MQTTContext_t * pContext );
  *
  * @param[in] pContext Initialized MQTT context.
  *
- * @return A non-zero number.
+ * @return A non-zero packet ID, or zero if @p pContext is NULL.
  */
 /* @[declare_mqtt_getpacketid] */
 uint16_t MQTT_GetPacketId( MQTTContext_t * pContext );
@@ -1420,6 +1439,7 @@ MQTTStatus_t MQTT_MatchTopic( const char * pTopicName,
  *
  * @return Returns one of the following:
  * - #MQTTBadParameter if the input SUBACK packet is invalid.<br>
+ * - #MQTTBadResponse if the SUBACK property length is malformed.<br>
  * - #MQTTSuccess if parsing the payload was successful.<br>
  *
  * <b>Example</b>

--- a/source/include/core_mqtt.h
+++ b/source/include/core_mqtt.h
@@ -97,8 +97,10 @@ typedef uint32_t ( * MQTTGetCurrentTimeFunc_t )( void );
  *
  * @note This callback will be called only if packets are deserialized with a
  * result of #MQTTSuccess or #MQTTServerRefused. The latter can be obtained
- * when deserializing a SUBACK indicating a broker's rejection of a subscribe,
- * or a CONNACK indicating a broker's rejection of a connection.
+ * when deserializing a CONNACK indicating a broker's rejection of a connection.
+ * For SUBACK and UNSUBACK, the deserialization result will be #MQTTSuccess even
+ * when individual topic filters are rejected; the application should inspect
+ * per-topic reason codes via #MQTTDeserializedInfo_t.pReasonCode.
  *
  * @param[in] pContext Initialized MQTT context.
  * @param[in] pPacketInfo Information on the type of incoming MQTT packet.

--- a/source/include/core_mqtt_serializer.h
+++ b/source/include/core_mqtt_serializer.h
@@ -243,7 +243,7 @@ typedef enum MQTTStatus
     MQTTSendFailed,                 /**< The transport send function failed. */
     MQTTRecvFailed,                 /**< The transport receive function failed. */
     MQTTBadResponse,                /**< An invalid packet was received from the server. It is recommended that application closes the connection.  */
-    MQTTServerRefused,              /**< The server refused a CONNECT or SUBSCRIBE. */
+    MQTTServerRefused,              /**< The server refused a CONNECT. */
     MQTTNoDataAvailable,            /**< No data available from the transport interface. */
     MQTTIllegalState,               /**< An illegal state in the state record. */
     MQTTStateCollision,             /**< A collision with an existing state record entry. */
@@ -1731,7 +1731,6 @@ MQTTStatus_t MQTT_DeserializePublish( const MQTTPacketInfo_t * pIncomingPacket,
  * @return Returns one of the following:
  * - #MQTTSuccess if the packet was successfully deserialized
  * - #MQTTBadParameter if invalid parameters are passed
- * - #MQTTServerRefused if the server explicitly rejected the request, either in the CONNACK or a SUBACK.
  * - #MQTTBadResponse if the packet type is invalid or packet parsing fails
  *
  * <b>Example</b>

--- a/source/include/core_mqtt_serializer.h
+++ b/source/include/core_mqtt_serializer.h
@@ -68,6 +68,40 @@
 /** @} */
 
 /**
+ * @addtogroup mqtt_constants
+ * @{
+ */
+
+/**
+ * @brief Convenience pointers for the @c pOptionalMqttPacketType parameter
+ * of the @c MQTTPropAdd_* functions.
+ *
+ * Pass one of these to enable runtime validation that a property is allowed
+ * in the intended packet type. Pass @ref MQTT_PROP_NO_VALIDATE (NULL) to
+ * skip validation.
+ *
+ * @code{c}
+ * MQTTPropAdd_SessionExpiry( &props, 3600, MQTT_PROP_VALIDATE_CONNECT );
+ * MQTTPropAdd_PayloadFormat( &props, 1,    MQTT_PROP_VALIDATE_PUBLISH );
+ * MQTTPropAdd_UserProp( &props, &up,       MQTT_PROP_NO_VALIDATE );
+ * @endcode
+ */
+static const uint8_t MQTT_PACKET_TYPE_CONNECT_VAL     = ( uint8_t ) 0x10U;  /**< @brief CONNECT value for property validation. */
+static const uint8_t MQTT_PACKET_TYPE_PUBLISH_VAL     = ( uint8_t ) 0x30U;  /**< @brief PUBLISH value for property validation. */
+static const uint8_t MQTT_PACKET_TYPE_SUBSCRIBE_VAL   = ( uint8_t ) 0x82U;  /**< @brief SUBSCRIBE value for property validation. */
+static const uint8_t MQTT_PACKET_TYPE_UNSUBSCRIBE_VAL = ( uint8_t ) 0xA2U;  /**< @brief UNSUBSCRIBE value for property validation. */
+static const uint8_t MQTT_PACKET_TYPE_DISCONNECT_VAL  = ( uint8_t ) 0xE0U;  /**< @brief DISCONNECT value for property validation. */
+
+#define MQTT_PROP_VALIDATE_CONNECT      ( &MQTT_PACKET_TYPE_CONNECT_VAL )      /**< @brief Validate property for CONNECT. */
+#define MQTT_PROP_VALIDATE_PUBLISH      ( &MQTT_PACKET_TYPE_PUBLISH_VAL )      /**< @brief Validate property for PUBLISH. */
+#define MQTT_PROP_VALIDATE_SUBSCRIBE    ( &MQTT_PACKET_TYPE_SUBSCRIBE_VAL )    /**< @brief Validate property for SUBSCRIBE. */
+#define MQTT_PROP_VALIDATE_UNSUBSCRIBE  ( &MQTT_PACKET_TYPE_UNSUBSCRIBE_VAL )  /**< @brief Validate property for UNSUBSCRIBE. */
+#define MQTT_PROP_VALIDATE_DISCONNECT   ( &MQTT_PACKET_TYPE_DISCONNECT_VAL )   /**< @brief Validate property for DISCONNECT. */
+#define MQTT_PROP_NO_VALIDATE           ( NULL )                               /**< @brief Skip packet type validation. */
+
+/** @} */
+
+/**
  * @ingroup mqtt_constants
  * @brief The size of MQTT PUBACK, PUBREC, PUBREL, and PUBCOMP packets, per MQTT spec.
  */

--- a/test/unit-test/core_mqtt_serializer_utest.c
+++ b/test/unit-test/core_mqtt_serializer_utest.c
@@ -3066,9 +3066,13 @@ void test_MQTTV5_suback( void )
     status = MQTT_DeserializeAck( &subackPacket, &packetIdentifier, &subackReasonCodes, &propBuffer, &properties );
     TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
 
-    packetBufferNoProperties[ 5 ] = 0x80; /* Change reason code to 0x01 (Unspecified error) */
+    packetBufferNoProperties[ 5 ] = 0x80; /* Change reason code to 0x80 (Unspecified error). */
     status = MQTT_DeserializeAck( &subackPacket, &packetIdentifier, &subackReasonCodes, &propBuffer, &properties );
-    TEST_ASSERT_EQUAL_INT( MQTTServerRefused, status );
+
+    /* Server rejection is no longer treated as a library-level error for
+     * SUBACK/UNSUBACK; the application inspects per-topic reason codes in the
+     * callback. */
+    TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
 
     /* Invalid Property Length. */
     subackPacket.remainingLength = 20;

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -6359,14 +6359,14 @@ void test_MQTT_ProcessLoop_handleIncomingAck_Happy_Paths5( void )
     resetProcessLoopParams( &expectParams );
     expectProcessLoopCalls( &context, &expectParams );
 
-    /* Verify that process loop is still successful when SUBACK indicates a
-     * server refusal. */
+    /* Verify that process loop is successful and the callback is invoked when
+     * SUBACK indicates server refusal of one or more topic filters. The
+     * deserializer now treats rejections as successful deserialization; the
+     * application inspects per-topic reason codes in the callback. */
     currentPacketType = MQTT_PACKET_TYPE_SUBACK;
     isEventCallbackInvoked = false;
     /* Set expected return values in the loop. */
     resetProcessLoopParams( &expectParams );
-    expectParams.deserializeStatus = MQTTServerRefused;
-    expectParams.processLoopStatus = MQTTServerRefused;
     expectProcessLoopCalls( &context, &expectParams );
     TEST_ASSERT_TRUE( isEventCallbackInvoked );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
MQTTProcessLoop calls return ServerRefused when a SUBACK/UNSUBACK says that one of the subs was rejected by the server. This commit modifies that behavior so that processloop returns success since the packet was well formed and the application should decide what is to be done with the subscription.

This PR also fixes documentation of the functions to say what they actually return.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
