### PR TITLE
Suppress MISRA violations for static helper variables

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -15,6 +15,33 @@ with ( Assuming rule 18.2 violation; with justification in point 1 ):
 grep 'MISRA Ref 18.2.1' . -rI
 ```
 
+#### Rule 2.2
+
+_Ref 2.2.1_
+
+- MISRA C-2012 Rule 2.2 states that there shall be no dead code. In
+  `core_mqtt_serializer.h`, the `MQTT_PACKET_TYPE_*_VAL` static const variables
+  back the `MQTT_PROP_VALIDATE_*` convenience macros. Each translation unit
+  that includes the header gets its own copy of these variables, and a TU that
+  does not use a particular `MQTT_PROP_VALIDATE_*` macro will leave the
+  corresponding variable unreferenced — Coverity flags this as dead code.
+  This is expected: the variables exist so that the address-of operator in the
+  macros yields a valid `const uint8_t *`, and the alternative (compound
+  literals) is not portable to C90. The cost is at most one byte of read-only
+  data per unused variable per TU, which is negligible.
+
+#### Rule 2.8
+
+_Ref 2.8.1_
+
+- MISRA C-2012 Rule 2.8 (Advisory) states that a project should not contain
+  unused object definitions. The `MQTT_PACKET_TYPE_*_VAL` static const
+  variables in `core_mqtt_serializer.h` are object definitions that may be
+  unused in any given translation unit that does not reference the
+  corresponding `MQTT_PROP_VALIDATE_*` macro. The deviation has the same
+  rationale as Rule 2.2 above: the variables must exist at file scope so the
+  macros can take their address, and the alternative is not portable to C90.
+
 #### Rule 10.5
 
 _Ref 10.5.1_

--- a/source/include/core_mqtt_serializer.h
+++ b/source/include/core_mqtt_serializer.h
@@ -86,10 +86,30 @@
  * MQTTPropAdd_UserProp( &props, &up,       MQTT_PROP_NO_VALIDATE );
  * @endcode
  */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-22 */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-28 */
+/* coverity[misra_c_2012_rule_2_2_violation] */
+/* coverity[misra_c_2012_rule_2_8_violation] */
 static const uint8_t MQTT_PACKET_TYPE_CONNECT_VAL     = ( uint8_t ) 0x10U;  /**< @brief CONNECT value for property validation. */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-22 */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-28 */
+/* coverity[misra_c_2012_rule_2_2_violation] */
+/* coverity[misra_c_2012_rule_2_8_violation] */
 static const uint8_t MQTT_PACKET_TYPE_PUBLISH_VAL     = ( uint8_t ) 0x30U;  /**< @brief PUBLISH value for property validation. */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-22 */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-28 */
+/* coverity[misra_c_2012_rule_2_2_violation] */
+/* coverity[misra_c_2012_rule_2_8_violation] */
 static const uint8_t MQTT_PACKET_TYPE_SUBSCRIBE_VAL   = ( uint8_t ) 0x82U;  /**< @brief SUBSCRIBE value for property validation. */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-22 */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-28 */
+/* coverity[misra_c_2012_rule_2_2_violation] */
+/* coverity[misra_c_2012_rule_2_8_violation] */
 static const uint8_t MQTT_PACKET_TYPE_UNSUBSCRIBE_VAL = ( uint8_t ) 0xA2U;  /**< @brief UNSUBSCRIBE value for property validation. */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-22 */
+/* More details at: https://github.com/FreeRTOS/coreMQTT/blob/main/MISRA.md#rule-28 */
+/* coverity[misra_c_2012_rule_2_2_violation] */
+/* coverity[misra_c_2012_rule_2_8_violation] */
 static const uint8_t MQTT_PACKET_TYPE_DISCONNECT_VAL  = ( uint8_t ) 0xE0U;  /**< @brief DISCONNECT value for property validation. */
 
 #define MQTT_PROP_VALIDATE_CONNECT      ( &MQTT_PACKET_TYPE_CONNECT_VAL )      /**< @brief Validate property for CONNECT. */


### PR DESCRIPTION
The static const uint8_t variables that back the MQTT_PROP_VALIDATE_* convenience macros get a private copy in every translation unit that includes core_mqtt_serializer.h. A TU that does not use a particular MQTT_PROP_VALIDATE_* macro leaves the corresponding variable unreferenced, which Coverity flags as MISRA Rule 2.2 (dead code) and Rule 2.8 (unused file-scope object definition).

Add coverity[misra_c_2012_rule_2_2_violation] and
coverity[misra_c_2012_rule_2_8_violation] suppressions above each static const declaration, with links to MISRA.md. Add Rule 2.2 and Rule 2.8 sections to MISRA.md documenting the rationale: the variables exist so the address-of operator in the macros produces a valid const uint8_t *, and the portable-to-C90 alternative (compound literals) is not viable.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
