### PR TITLE
Fix for MQTT subscription validation loop

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -2582,12 +2582,9 @@ static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * pC
             }
         }
 
-        if( status == MQTTSuccess )
+        for( iterator = 0U; ( status == MQTTSuccess ) && ( iterator < subscriptionCount ); iterator++ )
         {
-            for( iterator = 0U; iterator < subscriptionCount; iterator++ )
-            {
-                status = validateTopicFilter( pContext, pSubscriptionList, iterator, subscriptionType );
-            }
+            status = validateTopicFilter( pContext, pSubscriptionList, iterator, subscriptionType );
         }
     }
 

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -2582,8 +2582,13 @@ static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * pC
             }
         }
 
-        for( iterator = 0U; ( status == MQTTSuccess ) && ( iterator < subscriptionCount ); iterator++ )
+        for( iterator = 0U; iterator < subscriptionCount; iterator++ )
         {
+            status = validateTopicFilter( pContext, pSubscriptionList, iterator, subscriptionType );
+            if( status != MQTTSuccess )
+            {
+                break;
+            }
             status = validateTopicFilter( pContext, pSubscriptionList, iterator, subscriptionType );
         }
     }

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -2584,7 +2584,6 @@ static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * pC
 
         for( iterator = 0U; iterator < subscriptionCount; iterator++ )
         {
-            status = validateTopicFilter( pContext, pSubscriptionList, iterator, subscriptionType );
             if( status != MQTTSuccess )
             {
                 break;

--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -2588,6 +2588,7 @@ static MQTTStatus_t validateSubscribeUnsubscribeParams( const MQTTContext_t * pC
             {
                 break;
             }
+
             status = validateTopicFilter( pContext, pSubscriptionList, iterator, subscriptionType );
         }
     }


### PR DESCRIPTION
<!--- Title -->

Issue is that validation can accept invalid elements, because it does not interrupt loop on failure.
Proposed patch improves this.

<!-- If any, please provide issue ID. -->
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 
