### PR TITLE
Respond to unknown PUBREL with PUBCOMP reason code 0x92

### DIFF
--- a/source/core_mqtt.c
+++ b/source/core_mqtt.c
@@ -316,6 +316,26 @@ static MQTTStatus_t receiveConnackPacket( MQTTContext_t * pContext,
 static uint8_t getAckTypeToSend( MQTTPublishState_t state );
 
 /**
+ * @brief Respond to a PUBREL for which no publish record exists with a
+ * PUBCOMP carrying reason code 0x92 (Packet Identifier not found).
+ *
+ * A client that has lost its session state, for example because the device
+ * rebooted, may receive a PUBREL for an incoming QoS 2 publish it no longer
+ * knows about. MQTT v5 requires a PUBCOMP response to every PUBREL
+ * [MQTT-4.3.3-11]; reason code 0x92 informs the broker that the packet
+ * identifier was not found, which the specification notes is not an error
+ * during recovery.
+ *
+ * @param[in] pContext MQTT Connection context.
+ * @param[in] packetId Packet identifier of the received PUBREL.
+ *
+ * @return #MQTTSuccess if the PUBCOMP is sent; otherwise the error from
+ * sending it.
+ */
+static MQTTStatus_t respondToUnknownPubrel( MQTTContext_t * pContext,
+                                            uint16_t packetId );
+
+/**
  * @brief Send acks for received QoS 1/2 publishes.
  *
  * @param[in] pContext MQTT Connection context.
@@ -2032,6 +2052,46 @@ static MQTTStatus_t handleIncomingPublish( MQTTContext_t * pContext,
 
 /*-----------------------------------------------------------*/
 
+static MQTTStatus_t respondToUnknownPubrel( MQTTContext_t * pContext,
+                                            uint16_t packetId )
+{
+    MQTTStatus_t status;
+    uint32_t remainingLength = 0U;
+    uint32_t packetSize = 0U;
+
+    assert( pContext != NULL );
+
+    /* PUBCOMP with a reason code and zero-length properties. */
+    status = MQTT_GetAckPacketSize( &remainingLength,
+                                    &packetSize,
+                                    pContext->connectionProperties.serverMaxPacketSize,
+                                    0U );
+
+    if( ( status == MQTTSuccess ) && ( pContext->connectStatus != MQTTConnected ) )
+    {
+        status = ( pContext->connectStatus == MQTTNotConnected ) ? MQTTStatusNotConnected : MQTTStatusDisconnectPending;
+    }
+
+    if( status == MQTTSuccess )
+    {
+        status = buildAndSendAckWithProps( pContext,
+                                           MQTT_PACKET_TYPE_PUBCOMP,
+                                           packetId,
+                                           MQTT_REASON_PUBCOMP_PACKET_IDENTIFIER_NOT_FOUND,
+                                           remainingLength,
+                                           0U );
+    }
+
+    if( status == MQTTSuccess )
+    {
+        pContext->controlPacketSent = true;
+    }
+
+    return status;
+}
+
+/*-----------------------------------------------------------*/
+
 static MQTTStatus_t handlePublishAcks( MQTTContext_t * pContext,
                                        MQTTPacketInfo_t * pIncomingPacket )
 {
@@ -2046,6 +2106,7 @@ static MQTTStatus_t handlePublishAcks( MQTTContext_t * pContext,
     MQTTSuccessFailReasonCode_t * pSendReasonCode;
     MQTTSuccessFailReasonCode_t reasonCode = MQTT_INVALID_REASON_CODE;
     bool ackPropsAdded;
+    bool recoveredUnknownPubrel = false;
 
     MQTTReasonCodeInfo_t incomingReasonCode = { 0 };
 
@@ -2085,6 +2146,22 @@ static MQTTStatus_t handlePublishAcks( MQTTContext_t * pContext,
             LogInfo( ( "State record updated. New state=%s.",
                        MQTT_State_strerror( publishRecordState ) ) );
         }
+        else if( ( status == MQTTBadResponse ) && ( ackType == MQTTPubrel ) )
+        {
+            /* MQTT_UpdateStateAck returns MQTTBadResponse for a received
+             * PUBREL only when no publish record exists for the packet
+             * identifier. This happens when the session state was lost, for
+             * example because the device rebooted after sending the PUBREC.
+             * Respond with PUBCOMP and reason code 0x92 (Packet Identifier
+             * not found) so that both sides can discard the packet and the
+             * connection stays usable. */
+            LogWarn( ( "No matching record found for incoming PUBREL with packet"
+                       " id %hu. Responding with PUBCOMP with reason code 0x92.",
+                       ( unsigned short ) packetIdentifier ) );
+
+            recoveredUnknownPubrel = true;
+            status = respondToUnknownPubrel( pContext, packetIdentifier );
+        }
         else
         {
             LogError( ( "Updating the state engine for packet id %hu"
@@ -2094,7 +2171,7 @@ static MQTTStatus_t handlePublishAcks( MQTTContext_t * pContext,
         }
     }
 
-    if( ( status == MQTTSuccess ) &&
+    if( ( status == MQTTSuccess ) && ( recoveredUnknownPubrel == false ) &&
         ( pContext->clearFunction != NULL ) )
     {
         /* Outgoing publish QoS1: (Tx) PUBLISH -> (Rx) PUBACK. On receiving PubAck, the packet is acked and can be cleared. */
@@ -2135,7 +2212,7 @@ static MQTTStatus_t handlePublishAcks( MQTTContext_t * pContext,
         }
     }
 
-    if( status == MQTTSuccess )
+    if( ( status == MQTTSuccess ) && ( recoveredUnknownPubrel == false ) )
     {
         deserializedInfo.packetIdentifier = packetIdentifier;
         deserializedInfo.deserializationResult = status;

--- a/test/unit-test/core_mqtt_utest.c
+++ b/test/unit-test/core_mqtt_utest.c
@@ -7526,6 +7526,105 @@ void test_MQTT_ProcessLoop_handleIncomingAck_Error_Paths1( void )
     TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
 }
 
+/**
+ * @brief Receiving a PUBREL with no matching publish record, e.g. after the
+ * client lost its session state due to a reboot, must not fail the process
+ * loop: the library responds with PUBCOMP with reason code 0x92 (Packet
+ * Identifier not found) as required by the MQTT v5 specification.
+ */
+void test_MQTT_ProcessLoop_UnknownPubrel_RespondsWithPubcompNotFound( void )
+{
+    MQTTStatus_t status;
+    MQTTContext_t context = { 0 };
+    TransportInterface_t transport = { 0 };
+    MQTTFixedBuffer_t networkBuffer = { 0 };
+    uint16_t packetId = 1;
+    MQTTPacketInfo_t incomingPacket = { 0 };
+    MQTTPubAckInfo_t incomingRecords = { 0 };
+    MQTTPubAckInfo_t outgoingRecords = { 0 };
+    uint8_t ackPropsBuf[ 500 ];
+    size_t ackPropsBufLength = sizeof( ackPropsBuf );
+
+    setupTransportInterface( &transport );
+    setupNetworkBuffer( &networkBuffer );
+    incomingPacket.type = MQTT_PACKET_TYPE_PUBREL;
+    incomingPacket.remainingLength = MQTT_SAMPLE_REMAINING_LENGTH;
+    incomingPacket.headerLength = MQTT_SAMPLE_REMAINING_LENGTH;
+
+    MQTT_InitConnect_ExpectAnyArgsAndReturn( MQTTSuccess );
+    status = MQTT_Init( &context, &transport, getTime, eventCallback2, &networkBuffer );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+
+    context.connectStatus = MQTTConnected;
+    MQTTPropertyBuilder_Init_ExpectAnyArgsAndReturn( MQTTSuccess );
+    status = MQTT_InitStatefulQoS( &context,
+                                   &outgoingRecords, 4,
+                                   &incomingRecords, 4, ackPropsBuf, ackPropsBufLength );
+    TEST_ASSERT_EQUAL( MQTTSuccess, status );
+
+    MQTTPropBuilder_t ackPropsBuffer;
+    setupackPropsBuilder( &ackPropsBuffer );
+    context.ackPropsBuffer = ackPropsBuffer;
+
+    /* An unknown PUBREL is answered with PUBCOMP and the process loop
+     * succeeds. No state record is created or updated for the response. */
+    modifyIncomingPacketStatus = MQTTSuccess;
+    MQTT_ProcessIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_ProcessIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_DeserializeAck_ReturnThruPtr_pPacketId( &packetId );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
+    MQTT_GetAckPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
+    serializeAckFixed_Stub( MQTTV5_SerializeAckFixed_cb );
+    encodeVariableLength_Stub( encodeVariableLength_cb_1bytelength );
+    status = MQTT_ProcessLoop( &context );
+    TEST_ASSERT_EQUAL_INT( MQTTSuccess, status );
+
+    /* An error while sizing the PUBCOMP response is propagated. */
+    MQTT_ProcessIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_ProcessIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_DeserializeAck_ReturnThruPtr_pPacketId( &packetId );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
+    MQTT_GetAckPacketSize_ExpectAnyArgsAndReturn( MQTTBadParameter );
+    status = MQTT_ProcessLoop( &context );
+    TEST_ASSERT_EQUAL_INT( MQTTBadParameter, status );
+
+    /* No PUBCOMP is sent while a disconnect is pending. */
+    context.connectStatus = MQTTDisconnectPending;
+    MQTT_ProcessIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_ProcessIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_DeserializeAck_ReturnThruPtr_pPacketId( &packetId );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
+    MQTT_GetAckPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
+    status = MQTT_ProcessLoop( &context );
+    TEST_ASSERT_EQUAL_INT( MQTTStatusDisconnectPending, status );
+
+    /* No PUBCOMP is sent when the connection is not established. */
+    context.connectStatus = MQTTNotConnected;
+    MQTT_ProcessIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_ProcessIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_DeserializeAck_ReturnThruPtr_pPacketId( &packetId );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
+    MQTT_GetAckPacketSize_ExpectAnyArgsAndReturn( MQTTSuccess );
+    status = MQTT_ProcessLoop( &context );
+    TEST_ASSERT_EQUAL_INT( MQTTStatusNotConnected, status );
+
+    /* The recovery applies only to PUBREL: an unknown PUBCOMP still fails
+     * the process loop as before. */
+    context.connectStatus = MQTTConnected;
+    incomingPacket.type = MQTT_PACKET_TYPE_PUBCOMP;
+    MQTT_ProcessIncomingPacketTypeAndLength_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_ProcessIncomingPacketTypeAndLength_ReturnThruPtr_pIncomingPacket( &incomingPacket );
+    MQTT_DeserializeAck_ExpectAnyArgsAndReturn( MQTTSuccess );
+    MQTT_DeserializeAck_ReturnThruPtr_pPacketId( &packetId );
+    MQTT_UpdateStateAck_ExpectAnyArgsAndReturn( MQTTBadResponse );
+    status = MQTT_ProcessLoop( &context );
+    TEST_ASSERT_EQUAL_INT( MQTTBadResponse, status );
+}
+
 void test_MQTT_ProcessLoop_handleIncomingAck_Error_Paths2( void )
 {
     MQTTStatus_t status;


### PR DESCRIPTION
Description
-----------
When a client loses its QoS 2 session state (for example the device reboots after sending a PUBREC) and reconnects with a persistent session, the broker retransmits the pending PUBREL. Because `incomingPublishRecords` no longer contains the packet identifier, `MQTT_UpdateStateAck` fails, no response is sent, and every subsequent `MQTT_ProcessLoop` call returns `MQTTBadResponse` — the client is permanently stuck, as reported in #271.

MQTT v5 defines the recovery for exactly this situation: the receiver of a PUBREL must respond with a PUBCOMP [MQTT-4.3.3-11], and reason code 0x92 (Packet Identifier not found) exists to signal that the identifier was not known — the specification notes this "is not an error during recovery". The enum value `MQTT_REASON_PUBCOMP_PACKET_IDENTIFIER_NOT_FOUND` already exists in coreMQTT but was never sent on this path.

This PR makes `handlePublishAcks` detect the record-not-found case for an incoming PUBREL (`MQTT_UpdateStateAck` returns `MQTTBadResponse` for a PUBREL only when no record exists; a known record with an illegal transition yields `MQTTIllegalState`) and respond with a PUBCOMP carrying reason code 0x92 and no properties, reusing the existing `MQTT_GetAckPacketSize` and `buildAndSendAckWithProps` helpers. The process loop then returns successfully and the connection stays usable. The message is lost, which the issue reporter considered acceptable for this corner case. No state record is created for the response, the application callback is not invoked, and the retransmit hooks are not touched. Behavior for every other packet type and failure is unchanged — an unknown PUBACK/PUBREC/PUBCOMP still fails as before, covered by a regression scenario in the new test.

Scope note: on the outgoing side, publish persistence across reboots is now possible through the store/retrieve/clear retransmit hooks, so this PR focuses on the incoming PUBREL failure that rendered the client unusable. The symmetric case (unknown PUBREC answered with PUBREL 0x92) can be added as a follow-up if desired.

Coverage: all 16 new lines and all 18 new branches are covered by the added test (5 scenarios); totals remain at 97.5% lines / 93.8% branches.

Test Steps
-----------
Both CI unit-test configurations pass locally (5/5 test suites), including the new `test_MQTT_ProcessLoop_UnknownPubrel_RespondsWithPubcompNotFound`:

```
cmake -S test -B build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug \
  -DBUILD_CLONE_SUBMODULES=ON -DUNITTEST=1 [-DCOV_ANALYSIS=1] \
  -DCMAKE_C_FLAGS='--coverage -Wall -Wextra -Wsign-compare -Werror -DLIBRARY_LOG_LEVEL=LOG_DEBUG'
make -C build all
ctest --test-dir build -E system --output-on-failure
```

Formatting verified with uncrustify 0.69.0 using the config from FreeRTOS/CI-CD-Github-Actions.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Fixes #271

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
